### PR TITLE
Handle missing OpenAI key and API errors

### DIFF
--- a/api/run-command.js
+++ b/api/run-command.js
@@ -10,11 +10,16 @@ export default async function handler(req, res) {
   try {
     const { command } = req.body || { command: "(no command)" };
 
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return res.status(500).json({ error: "Missing OPENAI_API_KEY" });
+    }
+
     const r = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
         model: "gpt-4",
@@ -24,6 +29,11 @@ export default async function handler(req, res) {
         ]
       }),
     });
+
+    if (!r.ok) {
+      const errTxt = await r.text();
+      return res.status(r.status).json({ error: errTxt });
+    }
 
     const data = await r.json();
     const reply = data?.choices?.[0]?.message?.content ?? "No reply.";


### PR DESCRIPTION
## Summary
- Guard `/api/run-command` against missing `OPENAI_API_KEY`
- Surface errors from the OpenAI API instead of returning a generic reply

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896735cec2c8327815febb3205ceb23