### PR TITLE
Add run-command endpoint and Node 20 config

### DIFF
--- a/api/hello.js
+++ b/api/hello.js
@@ -1,3 +1,3 @@
 export default function handler(req, res) {
-  res.status(200).json({ ok: true, where: "api/hello" });
+  res.status(200).json({ ok: true });
 }

--- a/api/run-command.js
+++ b/api/run-command.js
@@ -1,0 +1,48 @@
+export default async function handler(req, res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: "Missing OPENAI_API_KEY" });
+  }
+
+  const { command } = req.body || {};
+  if (typeof command !== "string" || !command.trim()) {
+    return res.status(400).json({ error: "Missing command" });
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: command }],
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      return res.status(response.status).json({ error: err });
+    }
+
+    const data = await response.json();
+    const result = data.choices?.[0]?.message?.content || "";
+    return res.status(200).json({ result });
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/**/*.js": {
+      "runtime": "nodejs20.x"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/run-command` endpoint that calls OpenAI, enforces POST/CORS and returns the model output
- simplify `/api/hello` endpoint to return `{ ok: true }`
- configure Vercel to run API routes on Node 20

## Testing
- `node --input-type=module -e "import hello from './api/hello.js'; const res={ status:c=>({ json:o=>console.log('hello',c,o) }) }; hello({}, res); import run from './api/run-command.js'; const res2={ status:c=>({ json:o=>console.log('run',c,o), end:()=>{} }), setHeader:()=>{} }; run({method:'POST', body:{command:'hi'}}, res2);"`
- `npm test` *(fails: Could not read package.json)*

## Smoke Tests
- `curl -i https://<deployment>/api/hello`
- `curl -i -X POST https://<deployment>/api/run-command -H 'Content-Type: application/json' -d '{"command":"hello"}'`


------
https://chatgpt.com/codex/tasks/task_e_6896c535eb34832787886429ddae3282