### PR TITLE
Remove vercel.json; add public/index.html; fix 404

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mags Assistant</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 2rem; line-height: 1.5; }
+    ul { margin: 0.5rem 0 0 1.2rem; }
+  </style>
+</head>
+<body>
+  <h1>Mags Assistant</h1>
+  <p>✅ Service is up. Quick links:</p>
+  <ul>
+    <li><a href="/watch.html">Watch viewer</a></li>
+    <li><a href="/api/hello">/api/hello</a></li>
+    <li><a href="/api/rpa/diag">/api/rpa/diag</a></li>
+    <li><a href="/api/rpa/health">/api/rpa/health</a></li>
+  </ul>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,0 @@
-{
-  "functions": { "runtime": "nodejs20.x" },
-  "rewrites": [{ "source": "/watch", "destination": "/watch.html" }]
-}


### PR DESCRIPTION
## Summary
- remove `vercel.json` so deployment uses defaults
- add minimal `public/index.html` landing page with links

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/mags-assistant/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6896d37f26488327b40daa241edf57cb