### PR TITLE
Allow TTL parameter for RPA sessions

### DIFF
--- a/api/rpa/diag.js
+++ b/api/rpa/diag.js
@@ -1,3 +1,4 @@
 export default async function handler(req, res) {
-  return res.status(200).json({ ok: true });
+  const token = process.env.BROWSERLESS_API_KEY || process.env.BROWSERLESS_TOKEN;
+  return res.status(200).json({ ok: true, haveKey: Boolean(token) });
 }

--- a/public/watch.js
+++ b/public/watch.js
@@ -5,7 +5,11 @@
   try {
     log('Starting cloud browser…');
     const urlToOpen = 'https://dashboard.stripe.com/login';
-    const res = await fetch('/api/rpa/start?ttl=45000&url=' + encodeURIComponent(urlToOpen));
+    const res = await fetch('/api/rpa/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: urlToOpen, ttl: 300 })
+    });
     const json = await res.json();
     if (!res.ok || !json.ok) {
       log('Error: ' + (json.error || res.statusText));


### PR DESCRIPTION
## Summary
- allow optional `ttl` when starting a Browserless session
- include `haveKey` flag in `/api/rpa/diag`
- update watch page to POST start request with ttl

## Testing
- `node --input-type=module - <<'NODE'
process.env.BROWSERLESS_API_KEY = 'dummy';
// mock fetch
global.fetch = async () => ({ ok: true, text: async () => JSON.stringify({ viewerUrl: 'https://example.com/view', connect: { token: 'abc' } }) });
import handler from './api/rpa/start.js';
const req = { method: 'POST', body: { url: 'https://example.org', ttl: 300 } };
const res = { status(c){this.statusCode=c;return this;}, setHeader(){}, json(o){console.log('status', this.statusCode, o);}};
await handler(req, res);
NODE`
- `node --input-type=module - <<'NODE'
process.env.BROWSERLESS_API_KEY='dummy';
import handler from './api/rpa/diag.js';
const res={status(c){this.statusCode=c;return this;},json(o){console.log('status',c=o);}};
await handler({}, res);
NODE`
- `node --input-type=module - <<'NODE'
import handler from './api/hello.js';
const res={status(c){this.statusCode=c;return this;},json(o){console.log('status', this.statusCode, o);}};
await handler({}, res);
NODE`
- `node --input-type=module - <<'NODE'
import handler from './api/rpa/health.js';
const res={status(c){this.statusCode=c;return this;},json(o){console.log('status', this.statusCode, o);}};
await handler({}, res);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6896d840415c8327bb69762cbbf8bdac