### PR TITLE
refactor: keep viewer on page

### DIFF
--- a/public/watch/index.html
+++ b/public/watch/index.html
@@ -5,7 +5,13 @@
   <title>Mags Live Viewer</title>
 </head>
 <body>
-  <p id="status">Starting…</p>
+  <label>
+    URL:
+    <input id="url" type="url" value="https://example.com" />
+  </label>
+  <button id="start">Start</button>
+  <p>Sample target: <a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a></p>
+  <p id="status"></p>
   <script src="/watch/watch.js"></script>
 </body>
 </html>

--- a/public/watch/watch.js
+++ b/public/watch/watch.js
@@ -1,28 +1,37 @@
-(async () => {
+(() => {
+  const startBtn = document.getElementById('start');
+  const urlInput = document.getElementById('url');
   const status = document.getElementById('status');
   const log = (m) => { if (status) status.textContent = m; };
 
-  try {
+  startBtn?.addEventListener('click', async () => {
+    const url = urlInput?.value || '';
     log('Starting cloud browser…');
-    const urlToOpen = 'https://dashboard.stripe.com/login';
-    const res = await fetch('/api/rpa/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url: urlToOpen })
-    });
-    const json = await res.json();
-    if (!res.ok || !json.ok) {
-      log('Error: ' + (json.error || res.statusText));
-      return;
+    try {
+      const res = await fetch('/api/rpa/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url })
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        log('Error: ' + (json.error || res.statusText));
+        return;
+      }
+      const dest = json.viewerUrl || json.viewerUrlAlt || json.url;
+      if (dest) {
+        const link = document.createElement('a');
+        link.href = dest;
+        link.textContent = 'Open viewer';
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        status.innerHTML = '';
+        status.append('Started. ', link);
+      } else {
+        log('Started.');
+      }
+    } catch (e) {
+      log('Error: ' + e.message);
     }
-    const dest = json.viewerUrl || json.viewerUrlAlt || json.url;
-    if (dest) {
-      log('Opening…');
-      window.location.href = dest;
-    } else {
-      log('Error: missing url');
-    }
-  } catch (e) {
-    log('Error: ' + e.message);
-  }
+  });
 })();


### PR DESCRIPTION
## Summary
- remove hard-coded external redirect from watch page
- trigger RPA start with POST request and show viewer link
- ensure example links open in new tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68975f7483208327b0c71c83848b4790