### PR TITLE
Fix build scripts and health check routing

### DIFF
--- a/api/_lib/env.js
+++ b/api/_lib/env.js
@@ -1,0 +1,7 @@
+export function validateEnv(required = []) {
+  const missing = required.filter((n) => !process.env[n]);
+  if (missing.length) {
+    console.warn('Missing env vars:', missing.join(', '));
+  }
+}
+

--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,11 @@
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') return res.status(200).end();
+
+  return res.status(200).json({ ok: true, status: 200 });
+}
+
+export const config = { runtime: 'nodejs20.x' };
+

--- a/api/rpa/diag.js
+++ b/api/rpa/diag.js
@@ -1,18 +1,26 @@
+import { validateEnv } from '../_lib/env.js';
+
+validateEnv(['BROWSERLESS_BASE']);
+
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   if (req.method === 'OPTIONS') return res.status(200).end();
 
-  const base =
-    process.env.BROWSERLESS_BASE || 'https://production-sfo.browserless.io';
-  const haveKey = Boolean(
-    process.env.BROWSERLESS_TOKEN ||
-      process.env.BROWSERLESS_API_KEY ||
-      process.env.BROWSERLESS_KEY
-  );
-
-  res.status(200).json({ ok: true, base, haveKey });
+  try {
+    const base =
+      process.env.BROWSERLESS_BASE || 'https://production-sfo.browserless.io';
+    const haveKey = Boolean(
+      process.env.BROWSERLESS_TOKEN ||
+        process.env.BROWSERLESS_API_KEY ||
+        process.env.BROWSERLESS_KEY
+    );
+    res.status(200).json({ ok: true, base, haveKey });
+  } catch (err) {
+    console.error('rpa/diag', err);
+    res.status(500).json({ ok: false, error: 'Internal Server Error' });
+  }
 }
 
 export const config = { runtime: 'nodejs20.x' };

--- a/api/rpa/health.js
+++ b/api/rpa/health.js
@@ -1,17 +1,28 @@
+import { validateEnv } from '../_lib/env.js';
+
+validateEnv(['BROWSERLESS_BASE']);
+
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   if (req.method === 'OPTIONS') return res.status(200).end();
 
-  const haveKey = !!process.env.BROWSERLESS_API_KEY || !!process.env.BROWSERLESS_TOKEN || !!process.env.BROWSERLESS_KEY;
   try {
-    await fetch('https://example.com', { method: 'HEAD' });
-  } catch (_) {
-    // ignore errors
+    const haveKey =
+      !!process.env.BROWSERLESS_API_KEY ||
+      !!process.env.BROWSERLESS_TOKEN ||
+      !!process.env.BROWSERLESS_KEY;
+    try {
+      await fetch('https://example.com', { method: 'HEAD' });
+    } catch (_) {
+      // ignore errors
+    }
+    return res.status(200).json({ ok: true, haveKey });
+  } catch (err) {
+    console.error('rpa/health', err);
+    return res.status(500).json({ ok: false, error: 'Internal Server Error' });
   }
-
-  return res.status(200).json({ ok: true, haveKey });
 }
 
 export const config = { runtime: 'nodejs20.x' };

--- a/api/rpa/start.js
+++ b/api/rpa/start.js
@@ -1,3 +1,7 @@
+import { validateEnv } from '../_lib/env.js';
+
+validateEnv(['BROWSERLESS_BASE']);
+
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
@@ -9,55 +13,60 @@ export default async function handler(req, res) {
       .json({ ok: false, error: 'Method Not Allowed' });
   }
 
-  const body = req.body;
-  if (!body || typeof body !== 'object') {
-    return res.status(400).json({ ok: false, error: 'Invalid JSON' });
-  }
-  const url = typeof body.url === 'string' ? body.url.trim() : '';
-  if (!url) {
-    return res.status(400).json({ ok: false, error: 'Missing url' });
-  }
-
-  const base =
-    process.env.BROWSERLESS_BASE || 'https://production-sfo.browserless.io';
-  const token =
-    process.env.BROWSERLESS_TOKEN || process.env.BROWSERLESS_API_KEY;
-  const ttl =
-    typeof body.ttl === 'number' && !isNaN(body.ttl)
-      ? Math.min(body.ttl, 300000)
-      : 45000;
-  if (!token) {
-    return res.status(200).json({ ok: true, url, stub: true });
-  }
   try {
-    const r = await fetch(`${base}/sessions?token=${token}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ttl })
-    });
-    const text = await r.text();
-    if (!r.ok) {
-      console.error('rpa/start session error', r.status, text);
-      return res.status(r.status).json({ ok: false, error: text });
+    const body = req.body;
+    if (!body || typeof body !== 'object') {
+      return res.status(400).json({ ok: false, error: 'Invalid JSON' });
     }
-    let session = {};
+    const url = typeof body.url === 'string' ? body.url.trim() : '';
+    if (!url) {
+      return res.status(400).json({ ok: false, error: 'Missing url' });
+    }
+
+    const base =
+      process.env.BROWSERLESS_BASE || 'https://production-sfo.browserless.io';
+    const token =
+      process.env.BROWSERLESS_TOKEN || process.env.BROWSERLESS_API_KEY;
+    const ttl =
+      typeof body.ttl === 'number' && !isNaN(body.ttl)
+        ? Math.min(body.ttl, 300000)
+        : 45000;
+    if (!token) {
+      return res.status(200).json({ ok: true, url, stub: true });
+    }
     try {
-      session = JSON.parse(text);
-    } catch (_) {}
-    const id = session.id || session.sessionId;
-    const connect =
-      session.browserWSEndpoint || session.wsEndpoint || session.connect;
-    const viewerUrl = id
-      ? `${base}/playwright?token=${token}&sessionId=${id}&url=${encodeURIComponent(
-          url
-        )}`
-      : undefined;
-    return res
-      .status(200)
-      .json({ ok: true, url, viewerUrl, connect, ttl });
+      const r = await fetch(`${base}/sessions?token=${token}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ttl })
+      });
+      const text = await r.text();
+      if (!r.ok) {
+        console.error('rpa/start session error', r.status, text);
+        return res.status(r.status).json({ ok: false, error: text });
+      }
+      let session = {};
+      try {
+        session = JSON.parse(text);
+      } catch (_) {}
+      const id = session.id || session.sessionId;
+      const connect =
+        session.browserWSEndpoint || session.wsEndpoint || session.connect;
+      const viewerUrl = id
+        ? `${base}/playwright?token=${token}&sessionId=${id}&url=${encodeURIComponent(
+            url
+          )}`
+        : undefined;
+      return res
+        .status(200)
+        .json({ ok: true, url, viewerUrl, connect, ttl });
+    } catch (err) {
+      console.error('rpa/start', err);
+      return res.status(200).json({ ok: true, url, stub: true });
+    }
   } catch (err) {
-    console.error('rpa/start', err);
-    return res.status(200).json({ ok: true, url, stub: true });
+    console.error('rpa/start parse', err);
+    return res.status(500).json({ ok: false, error: 'Internal Server Error' });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "mags-assistant",
   "private": true,
+  "type": "module",
   "engines": {
     "node": "20.x"
   },
   "scripts": {
+    "build": "echo 'nothing to build'",
+    "start": "node server.js",
     "test": "echo 'no tests'"
   }
 }

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Not Found</title>
+</head>
+<body>
+  <h1>404 - Page Not Found</h1>
+  <p>The page you are looking for does not exist.</p>
+  <a href="/">Back to home</a>
+</body>
+</html>
+

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
 <body>
   <h1>Mags Assistant</h1>
   <ul>
-    <li><a href="/watch">Viewer</a></li>
+    <li><a href="/viewer">Viewer</a></li>
     <li><a href="/api/hello">/api/hello</a></li>
     <li><a href="/api/rpa/diag">/api/rpa/diag</a></li>
     <li><a href="/api/rpa/health">/api/rpa/health</a></li>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,98 @@
+import { createServer } from 'http';
+import { parse } from 'url';
+import { join } from 'path';
+import { readFile } from 'fs/promises';
+import { existsSync, statSync } from 'fs';
+import { validateEnv } from './api/_lib/env.js';
+
+const publicDir = join(process.cwd(), 'public');
+
+validateEnv();
+
+async function readBody(req) {
+  return new Promise((resolve) => {
+    let data = '';
+    req.on('data', (chunk) => {
+      data += chunk;
+    });
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (_) {
+        resolve({});
+      }
+    });
+  });
+}
+
+async function sendFile(res, filePath, contentType = 'text/html') {
+  try {
+    const data = await readFile(filePath);
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  } catch (err) {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not Found');
+  }
+}
+
+createServer(async (req, res) => {
+  let { pathname } = parse(req.url, true);
+
+  if (pathname === '/viewer' || pathname.startsWith('/viewer/')) {
+    pathname = pathname.replace('/viewer', '/watch');
+  }
+  if (pathname === '/health') {
+    pathname = '/api/health';
+  }
+
+  if (pathname.startsWith('/api/')) {
+    try {
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        req.body = await readBody(req);
+      }
+      if (!res.status) {
+        res.status = (code) => {
+          res.statusCode = code;
+          return res;
+        };
+      }
+      if (!res.json) {
+        res.json = (obj) => {
+          if (!res.headersSent) {
+            res.setHeader('Content-Type', 'application/json');
+          }
+          res.end(JSON.stringify(obj));
+        };
+      }
+      const mod = await import(`./${pathname.slice(1)}.js`);
+      await mod.default(req, res);
+    } catch (err) {
+      console.error('api error', err);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, error: 'Internal Server Error' }));
+    }
+    return;
+  }
+
+  const filePath = join(publicDir, pathname === '/' ? 'index.html' : pathname);
+  if (existsSync(filePath) && !statSync(filePath).isDirectory()) {
+    await sendFile(res, filePath);
+    return;
+  }
+  const indexFile = join(filePath, 'index.html');
+  if (existsSync(indexFile)) {
+    await sendFile(res, indexFile);
+    return;
+  }
+  const notFound = join(publicDir, '404.html');
+  if (existsSync(notFound)) {
+    await sendFile(res, notFound);
+    return;
+  }
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not Found');
+}).listen(process.env.PORT || 3000, () => {
+  console.log(`Server running on http://localhost:${process.env.PORT || 3000}`);
+});
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    { "source": "/viewer", "destination": "/watch" },
+    { "source": "/viewer/(.*)", "destination": "/watch/$1" },
+    { "source": "/health", "destination": "/api/health" }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- enable ESM, add build/start scripts, and supply a simple Node server for local testing
- add `/health` endpoint with vercel rewrites and a basic 404 page
- harden RPA API handlers with validation, error handling, and environment checks

## Testing
- `npm test`
- `curl -s http://localhost:3000/health`
- `curl -s http://localhost:3000/api/rpa/diag`
- `curl -s -o /tmp/viewer.html http://localhost:3000/viewer && head -n 5 /tmp/viewer.html`


------
https://chatgpt.com/codex/tasks/task_e_68976d4ed37c8327acc204eea62a680b