### PR TITLE
feat: brand CSS + Task Bar (voice/presets), viewer fix, video pipeline, and agent actions

### DIFF
--- a/api/agent/index.js
+++ b/api/agent/index.js
@@ -1,0 +1,115 @@
+import { cors, json } from "../../lib/http.js";
+
+export const config = { runtime: "nodejs" };
+
+export default async function handler(req, res) {
+  try {
+    if (cors(req, res)) return;
+    if (req.method !== "POST") {
+      return json(res, 405, { ok: false, error: "Method not allowed" });
+    }
+    const body = req.body && typeof req.body === "object" ? req.body : {};
+    const action = body.action;
+    const params = body.params || {};
+    const baseUrl = `${req.headers["x-forwarded-proto"] || "http"}://${req.headers.host}`;
+
+    if (action === "pingUrl") {
+      const url = params.url;
+      try {
+        const r = await fetch(url, { method: "HEAD" });
+        return json(res, 200, { ok: true, status: r.status });
+      } catch (e) {
+        return json(res, 200, { ok: false, error: e.message });
+      }
+    }
+
+    if (action === "vercelDeployStatus") {
+      try {
+        const r = await fetch("https://www.vercel-status.com/api/v2/status.json");
+        const data = await r.json();
+        return json(res, 200, { ok: true, status: data.status });
+      } catch (e) {
+        return json(res, 200, { ok: false, error: e.message });
+      }
+    }
+
+    if (action === "listOpenPRs") {
+      const repo = process.env.GITHUB_REPO || "messyandmagnetic/mags-assistant";
+      try {
+        const r = await fetch(`https://api.github.com/repos/${repo}/pulls?state=open`, {
+          headers: process.env.GITHUB_TOKEN
+            ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+            : {},
+        });
+        const data = await r.json();
+        const prs = Array.isArray(data)
+          ? data.map((p) => ({ number: p.number, title: p.title, url: p.html_url }))
+          : [];
+        return json(res, 200, { ok: true, prs });
+      } catch (e) {
+        return json(res, 200, { ok: false, error: e.message });
+      }
+    }
+
+    if (action === "createIssue") {
+      const repo = process.env.GITHUB_REPO || "messyandmagnetic/mags-assistant";
+      if (!process.env.GITHUB_TOKEN) {
+        return json(res, 200, { ok: false, error: "missing token" });
+      }
+      try {
+        const r = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          },
+          body: JSON.stringify({
+            title: params.title || "(no title)",
+            body: params.body || "",
+          }),
+        });
+        const data = await r.json();
+        return json(res, 200, {
+          ok: true,
+          issue: { number: data.number, url: data.html_url },
+        });
+      } catch (e) {
+        return json(res, 200, { ok: false, error: e.message });
+      }
+    }
+
+    if (action === "healthBundle" || action === "summarizeStatus") {
+      try {
+        const [hello, health, diag] = await Promise.all([
+          fetch(baseUrl + "/api/hello").then((r) => r.json()).catch(() => ({ ok: false })),
+          fetch(baseUrl + "/api/rpa/health").then((r) => r.json()).catch(() => ({ ok: false })),
+          fetch(baseUrl + "/api/rpa/diag").then((r) => r.json()).catch(() => ({ ok: false })),
+        ]);
+        if (action === "summarizeStatus") {
+          return json(res, 200, { ok: true, summary: { hello, health, diag } });
+        }
+        return json(res, 200, { ok: true, hello, health, diag });
+      } catch (e) {
+        return json(res, 200, { ok: false, error: e.message });
+      }
+    }
+
+    if (action === "createVideoTask") {
+      try {
+        const r = await fetch(baseUrl + "/api/video/edit", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(params || {}),
+        });
+        const data = await r.json();
+        return json(res, 200, data);
+      } catch (e) {
+        return json(res, 200, { ok: false, error: e.message });
+      }
+    }
+
+    return json(res, 400, { ok: false, error: "Unknown action" });
+  } catch (err) {
+    return json(res, 500, { ok: false, error: err.message || "Internal error" });
+  }
+}

--- a/api/video/edit.js
+++ b/api/video/edit.js
@@ -1,0 +1,44 @@
+import { cors, json } from "../../lib/http.js";
+
+export const config = { runtime: "nodejs" };
+
+const overlayMap = {
+  sparkles: process.env.OVERLAY_SPARKLES_URL,
+  flowers: process.env.OVERLAY_FLOWERS_URL,
+  leaf: process.env.OVERLAY_LEAF_URL,
+  feather: process.env.OVERLAY_FEATHER_URL,
+  teacup: process.env.OVERLAY_TEACUP_URL,
+};
+
+export default async function handler(req, res) {
+  try {
+    if (cors(req, res)) return;
+    if (req.method !== "POST") {
+      return json(res, 405, { ok: false, error: "Method not allowed" });
+    }
+    const params = req.body && typeof req.body === "object" ? req.body : {};
+    const theme = params.theme || "pastel-script";
+    const ar916 = params.ar916 !== false;
+    const ar11 = !!params.ar11;
+    const overlayNames = Array.isArray(params.overlays)
+      ? params.overlays
+      : typeof params.overlays === "string"
+      ? [params.overlays]
+      : [];
+    const overlays = overlayNames.map((n) => overlayMap[n]).filter(Boolean);
+    const jobs = [];
+    const baseId = Math.random().toString(36).slice(2, 8);
+    const makeJob = (ratio) => ({
+      id: `${baseId}-${ratio.replace(/\W/g, '')}`,
+      ratio,
+      theme,
+      overlays,
+      watermark: process.env.BRAND_WATERMARK_URL || null,
+    });
+    if (ar916) jobs.push(makeJob("9:16"));
+    if (ar11) jobs.push(makeJob("1:1"));
+    return json(res, 200, { ok: true, jobs });
+  } catch (err) {
+    return json(res, 500, { ok: false, error: err.message || "Internal error" });
+  }
+}

--- a/api/video/status.js
+++ b/api/video/status.js
@@ -1,0 +1,18 @@
+import { cors, json } from "../../lib/http.js";
+
+export const config = { runtime: "nodejs" };
+
+export default async function handler(req, res) {
+  try {
+    if (cors(req, res)) return;
+    if (req.method !== "GET") {
+      return json(res, 405, { ok: false, error: "Method not allowed" });
+    }
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const ids = url.searchParams.getAll("id");
+    const jobs = ids.map((id) => ({ id, status: "queued" }));
+    return json(res, 200, { ok: true, jobs });
+  } catch (err) {
+    return json(res, 500, { ok: false, error: err.message || "Internal error" });
+  }
+}

--- a/api/video/webhook.js
+++ b/api/video/webhook.js
@@ -1,0 +1,29 @@
+import { cors, json } from "../../lib/http.js";
+
+export const config = { runtime: "nodejs" };
+
+export default async function handler(req, res) {
+  try {
+    if (cors(req, res)) return;
+    if (req.method !== "POST") {
+      return json(res, 405, { ok: false, error: "Method not allowed" });
+    }
+    const body = req.body && typeof req.body === "object" ? req.body : {};
+    if (process.env.BLOB_READ_WRITE_TOKEN) {
+      try {
+        const id = body.id || Math.random().toString(36).slice(2, 8);
+        const url = `https://blob.vercel-storage.com/upload?token=${process.env.BLOB_READ_WRITE_TOKEN}&pathname=video-jobs/${id}.json`;
+        await fetch(url, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+      } catch (e) {
+        console.warn("blob upload failed", e);
+      }
+    }
+    return json(res, 200, { ok: true });
+  } catch (err) {
+    return json(res, 500, { ok: false, error: err.message || "Internal error" });
+  }
+}

--- a/lib/http.js
+++ b/lib/http.js
@@ -4,7 +4,18 @@ export function json(res, code, body) {
 }
 
 export function cors(req, res) {
-  res.setHeader("Access-Control-Allow-Origin", "*");
+  const allowed = process.env.ALLOWED_ORIGINS || "*";
+  if (allowed === "*") {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+  } else {
+    const origin = req.headers.origin || "";
+    const list = allowed.split(",").map((s) => s.trim());
+    if (origin && list.includes(origin)) {
+      res.setHeader("Access-Control-Allow-Origin", origin);
+    } else {
+      res.setHeader("Access-Control-Allow-Origin", list[0] || "*");
+    }
+  }
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
   res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
   if (req.method === "OPTIONS") {

--- a/public/brand.css
+++ b/public/brand.css
@@ -1,0 +1,22 @@
+@import url('https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Quicksand:wght@400;600&display=swap');
+:root{--rose:#D6A5B1;--lavender:#C6B4CE;--sage:#A3B18A;--cream:#FDF6EC;--ink:#2F2A2A;--smoke:#EFEAEC;--shadow:rgba(0,0,0,.10);--focus:#F0D9FF;--radius:12px}
+html,body{background:var(--cream);color:var(--ink);font-family:Quicksand,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0}
+.container{max-width:960px;margin:24px auto;padding:0 16px}
+h1,h2,h3{font-family:"Dancing Script",cursive;font-weight:600;letter-spacing:.2px;margin:0 0 12px;color:var(--ink)}
+.card{background:#fff;border:1px solid var(--smoke);border-radius:var(--radius);box-shadow:0 6px 20px var(--shadow);padding:16px;margin:16px 0}
+.button-row{display:flex;flex-wrap:wrap;gap:8px}
+a.button,button.button{display:inline-block;background:#fff;border:1px solid var(--smoke);border-radius:10px;padding:10px 14px;text-decoration:none;color:var(--ink);cursor:pointer;transition:transform .06s,box-shadow .06s,background .2s}
+a.button:hover,button.button:hover{background:var(--cream);transform:translateY(-1px);box-shadow:0 4px 14px var(--shadow)}
+a.button:focus,button.button:focus,input:focus,select:focus{outline:3px solid var(--focus);outline-offset:1px}
+.badge{display:inline-flex;align-items:center;font-size:12px;padding:4px 8px;border-radius:20px;background:var(--lavender);color:#fff}
+hr{border:0;height:1px;background:var(--smoke);margin:16px 0}
+input[type="text"],input[type="url"],input[type="file"],select{background:#fff;border:1px solid var(--smoke);border-radius:10px;padding:10px 12px;color:var(--ink)}
+label{display:inline-flex;gap:8px;align-items:center;margin:6px 10px 6px 0}
+#taskForm{display:flex;flex-direction:column;gap:8px}
+#taskInput{width:100%;max-width:720px}
+#presetButtons button{background:#fff;border:1px solid var(--smoke);border-radius:999px;padding:8px 12px}
+#micBtn{border:1px solid var(--rose);background:linear-gradient(180deg,#fff,#fff0f6);color:var(--rose);border-radius:999px;padding:8px 12px}
+.viewer-wrap{padding:16px}
+.viewer-wrap h1{color:var(--rose)}
+pre{background:#fff;border:1px solid var(--smoke);border-radius:10px;padding:12px;overflow:auto}
+.button.rose{border-color:var(--rose);color:var(--rose)}.button.lav{border-color:var(--lavender);color:var(--lavender)}.button.sage{border-color:var(--sage);color:var(--sage)}

--- a/public/index.html
+++ b/public/index.html
@@ -4,30 +4,131 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Mags Assistant</title>
-  <style>
-    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:2rem;line-height:1.5}
-    code{background:#f2f2f2;padding:.15rem .35rem;border-radius:.25rem}
-    .grid{display:grid;gap:12px;max-width:750px}
-    a.button{display:inline-block;border:1px solid #ddd;border-radius:8px;padding:10px 14px;text-decoration:none}
-    pre{background:#fafafa;border:1px solid #eee;border-radius:8px;padding:10px;overflow:auto}
-  </style>
+  <link rel="stylesheet" href="/brand.css">
 </head>
 <body>
-  <h1>✅ Mags Assistant is live</h1>
-  <p>Quick checks and tools:</p>
-  <div class="grid">
-    <a class="button" href="/api/hello">Hello</a>
-    <a class="button" href="/api/rpa/health">Health</a>
-    <a class="button" href="/api/rpa/diag">Diag</a>
-    <a class="button" href="/viewer">Viewer</a>
+<div class="container">
+  <h1>✅ Mags Assistant</h1>
+  <div class="card">
+    <h2>Quick checks</h2>
+    <div class="button-row">
+      <a class="button rose" href="/api/hello">/api/hello</a>
+      <a class="button lav"  href="/api/rpa/health">/api/rpa/health</a>
+      <a class="button sage" href="/api/rpa/diag">/api/rpa/diag</a>
+      <a class="button"      href="/watch">Viewer</a>
+    </div>
   </div>
 
-  <h2>Try the RPA start endpoint</h2>
-  <p>POST JSON to <code>/api/rpa/start</code> (example payload below).</p>
-  <pre>{
-  "url": "https://example.com"
-}</pre>
+  <div class="card">
+    <h2>Task Bar</h2>
+    <form id="taskForm">
+      <input id="taskInput" placeholder="Type or speak a command…" />
+      <div style="margin-top:8px;display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
+        <input type="file" id="taskFile" accept="video/*">
+        <button id="runTask" class="button">Run</button>
+        <button type="button" id="micBtn" class="button">🎤</button>
+      </div>
+    </form>
+    <div id="presetButtons" style="margin-top:8px;">
+      <button type="button" class="button" data-cmd="ping https://example.com">Ping Example</button>
+      <button type="button" class="button" data-cmd="vercel status">Vercel Status</button>
+      <button type="button" class="button" data-cmd="list prs">List PRs</button>
+      <button type="button" class="button" data-cmd="health bundle">Health Check</button>
+      <button type="button" class="button" data-cmd="edit video theme: pastel-script overlays: sparkles,leaf">Quick Pastel Video</button>
+    </div>
+    <pre id="taskOut"></pre>
+    <p style="opacity:.7">Examples: <code>ping https://example.com</code> · <code>create issue Fix Stripe | body: normalize descriptors</code> · <code>edit video theme: pastel-script overlays: sparkles,leaf</code></p>
+  </div>
 
-  <p>If any endpoint returns an error, open an issue with the ID shown in the response.</p>
+  <div class="card">
+    <h2>Video Editor</h2>
+    <form id="videoForm">
+      <input type="file" id="file" accept="video/*">
+      <input type="text" id="title" placeholder="Headline (optional)">
+      <label><input type="checkbox" id="ar916" checked> 9:16</label>
+      <label><input type="checkbox" id="ar11"> 1:1</label>
+      <label><input type="checkbox" id="captions" checked> Auto-captions</label>
+      <label>Theme:
+        <select id="theme">
+          <option value="pastel-script">Pastel Script</option>
+          <option value="chalkboard-cottage">Chalkboard Cottage</option>
+          <option value="wildflower-field">Wildflower Field</option>
+          <option value="minimal-clean">Minimal Clean Pastel</option>
+        </select>
+      </label>
+      <label><input type="checkbox" id="autoHooks" checked> Auto hook trim</label>
+      <label><input type="checkbox" id="autoSubclips" checked> Make highlights</label>
+      <label><input type="checkbox" id="makeThumb" checked> Generate thumbnail</label>
+      <label>Overlays:
+        <select id="overlays" multiple>
+          <option value="sparkles">sparkles</option>
+          <option value="flowers">flowers</option>
+          <option value="leaf">leaf</option>
+          <option value="feather">feather</option>
+          <option value="teacup">teacup</option>
+        </select>
+      </label>
+      <button class="button">Render</button>
+    </form>
+    <pre id="videoOut"></pre>
+  </div>
+</div>
+
+<script>
+function parseCommand(s) {
+  const txt = s.trim(), lower = txt.toLowerCase();
+  const pick = (k)=>{const m=txt.match(new RegExp(`${k}\\s*:\\s*([^|]+)`,'i'));return m?m[1].trim():null};
+  if (lower.startsWith('ping ')) return {type:'agent',action:'pingUrl',params:{url:txt.split(/\\s+/)[1]}};
+  if (lower.startsWith('vercel status')) return {type:'agent',action:'vercelDeployStatus',params:{}};
+  if (lower.startsWith('list prs')||lower.startsWith('list pr')) return {type:'agent',action:'listOpenPRs',params:{}};
+  if (lower.startsWith('create issue')) {const body=pick('body');const title=txt.replace(/create issue/i,'').split('|')[0].trim()||'(no title)';return {type:'agent',action:'createIssue',params:{title,body:body||''}};}
+  if (lower.startsWith('health')) return {type:'agent',action:'healthBundle',params:{}};
+  if (lower.startsWith('edit video')) {const theme=pick('theme')||'pastel-script';const overlays=(pick('overlays')||'').split(',').map(s=>s.trim()).filter(Boolean);const url=pick('url');return {type:'video',params:{theme,overlays,ar916:true,captions:true,autoHooks:true,autoSubclips:true,makeThumb:true,url:url||null}};}
+  return {type:'agent',action:'healthBundle',params:{}};
+}
+const j=v=>JSON.stringify(v,null,2);
+
+document.getElementById('taskForm').addEventListener('submit', async (e)=>{
+  e.preventDefault(); runTask(parseCommand(document.getElementById('taskInput').value));
+});
+document.getElementById('presetButtons').addEventListener('click',(e)=>{
+  if(e.target.tagName==='BUTTON'){const c=e.target.dataset.cmd;document.getElementById('taskInput').value=c;runTask(parseCommand(c));}
+});
+async function runTask(parsed){
+  const out=document.getElementById('taskOut'); const file=document.getElementById('taskFile').files[0]||null;
+  out.textContent='Running…\n'+j(parsed);
+  try{
+    if(parsed.type==='agent'){
+      const r=await fetch('/api/agent',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:parsed.action,params:parsed.params})});
+      out.textContent=j(await r.json()); return;
+    }
+    if(parsed.type==='video'){
+      const fd=new FormData(); if(file) fd.append('file',file); if(parsed.params.url) fd.append('url',parsed.params.url);
+      fd.append('theme',parsed.params.theme); fd.append('captions',true); fd.append('ar916',true); fd.append('ar11',false);
+      fd.append('autoHooks',true); fd.append('autoSubclips',true); fd.append('makeThumb',true);
+      parsed.params.overlays.forEach(v=>fd.append('overlays[]',v));
+      const r=await fetch('/api/video/edit',{method:'POST',body:fd}); out.textContent=j(await r.json()); return;
+    }
+    out.textContent=j({ok:false,error:'Unknown type'});
+  }catch(e){ out.textContent=j({ok:false,error:String(e)}); }
+}
+// Voice input
+document.getElementById('micBtn').addEventListener('click',()=>{
+  const SR=window.SpeechRecognition||window.webkitSpeechRecognition; if(!SR){alert('Voice not supported');return;}
+  const rec=new SR(); rec.lang='en-US';
+  rec.onresult=(evt)=>{const text=evt.results[0][0].transcript;document.getElementById('taskInput').value=text;runTask(parseCommand(text));};
+  rec.start();
+});
+// Video form submit
+document.getElementById('videoForm').onsubmit=async(e)=>{
+  e.preventDefault(); const fd=new FormData();
+  const f=file.files[0]; if(f) fd.append('file',f);
+  fd.append('title', title.value); fd.append('ar916',ar916.checked); fd.append('ar11',ar11.checked);
+  fd.append('captions',captions.checked); fd.append('theme',theme.value);
+  fd.append('autoHooks',autoHooks.checked); fd.append('autoSubclips',autoSubclips.checked); fd.append('makeThumb',makeThumb.checked);
+  Array.from(overlays.selectedOptions).forEach(o=>fd.append('overlays[]',o.value));
+  videoOut.textContent='Uploading…'; const r=await fetch('/api/video/edit',{method:'POST',body:fd}); videoOut.textContent=j(await r.json());
+};
+</script>
 </body>
 </html>

--- a/public/watch.html
+++ b/public/watch.html
@@ -4,12 +4,16 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Viewer</title>
+  <link rel="stylesheet" href="/brand.css">
 </head>
 <body>
+<div class="container viewer-wrap">
+  <h1>Viewer</h1>
   <input id="targetUrl" type="text" />
-  <button id="startBtn">Start</button>
+  <button id="startBtn" class="button">Start</button>
   <small><a href="?url=https://example.com">Sample target</a></small>
   <div id="status"></div>
-  <script src="/watch.js"></script>
+</div>
+<script src="/watch.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add pastel cottagecore brand CSS and apply to landing and viewer
- introduce Task Bar with voice input, presets, and video editor
- expand agent API for pings, Vercel status, PR/issue management, summaries, and video task proxy
- stub Shotstack-based video pipeline with status and webhook endpoints

## Testing
- `node --check api/agent/index.js api/video/edit.js api/video/status.js api/video/webhook.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978311a9788327afc506cea5cef765