### PR TITLE
Harden preview check workflow

### DIFF
--- a/.github/workflows/preview-check.yml
+++ b/.github/workflows/preview-check.yml
@@ -1,9 +1,8 @@
 name: Preview Checks
 on: [pull_request]
 jobs:
-  curl:
+  smoke:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -15,8 +14,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          url=""
           for i in {1..20}; do
-            url=$(gh api repos/${{ github.repository }}/deployments --jq '.[] | select(.environment=="Preview") | .payload.web_url' | head -n 1)
+            url=$(gh api repos/${{ github.repository }}/deployments --jq '.[] | select(.environment=="Preview") | .payload.web_url' 2>/dev/null | head -n 1 || true)
             if [ -n "$url" ] && [ "$url" != "null" ]; then
               echo "url=$url" >> $GITHUB_OUTPUT
               break

--- a/api/router.js
+++ b/api/router.js
@@ -1,5 +1,7 @@
 import { cors, ok, fail, json } from "../lib/http.js";
 
+export const config = { runtime: "nodejs" };
+
 export default async function handler(req, res) {
   console.log(`${req.method} ${req.url}`);
   try {


### PR DESCRIPTION
## Summary
- ensure Vercel API router runs on the Node runtime
- make preview smoke test workflow resilient and fail only on real HTTP errors

## Testing
- `npm test`
- `npx vercel --prod` *(fails: 403 Forbidden to registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68979719a8c4832795a39bdeac76be44