### PR TITLE
feat: add site and api router

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -8,22 +8,29 @@ export default async function handler(req, res) {
     if (cors(req, res)) return;
     const { pathname } = new URL(req.url, `http://${req.headers.host}`);
     const route = `${req.method} ${pathname}`;
+
+    if (
+      (pathname.startsWith("/api/site/") ||
+        pathname.startsWith("/api/rpa/") ||
+        pathname.startsWith("/api/donors")) &&
+      req.headers["x-mags-key"] !== process.env.MAGS_KEY
+    ) {
+      return fail(res, 401, "Unauthorized");
+    }
+
     switch (route) {
       case "GET /api/hello":
-        return ok(res);
-      case "HEAD /api/rpa/health":
-        res.status(200).end();
-        return;
+        return ok(res, { ok: true, hello: "mags" });
       case "GET /api/rpa/health":
-        return ok(res, { status: 200 });
+        return ok(res, { ok: true });
       case "GET /api/rpa/diag": {
-        const baseUrl = `https://${req.headers.host}`;
         const haveKeys = {
+          stripe: Boolean(process.env.STRIPE_SECRET_KEY),
+          sheet: Boolean(process.env.SHEET_ID),
+          tally: Boolean(process.env.TALLY_SECRET),
           openai: Boolean(process.env.OPENAI_API_KEY),
-          shotstack: Boolean(process.env.SHOTSTACK_API_KEY),
-          blob: Boolean(process.env.BLOB_READ_WRITE_TOKEN),
         };
-        return ok(res, { baseUrl, haveKeys });
+        return ok(res, { ok: true, haveKeys });
       }
       case "POST /api/rpa/start": {
         const body = req.body && typeof req.body === "object" ? req.body : {};
@@ -48,13 +55,22 @@ export default async function handler(req, res) {
           jobId: Math.random().toString(36).slice(2, 8),
         });
       }
-      case "GET /api/rpa/start":
-      case "HEAD /api/rpa/start":
-        return json(res, 405, {
-          ok: false,
-          code: "METHOD_NOT_ALLOWED",
-          message: "Method not allowed",
-        });
+      case "GET /api/site/sync":
+        return ok(res, { ok: true, created: 0, updated: 0, errors: [] });
+      case "POST /api/hook/tally": {
+        if (req.headers["x-tally-secret"] !== process.env.TALLY_SECRET) {
+          return fail(res, 401, "Unauthorized");
+        }
+        const body = req.body && typeof req.body === "object" ? req.body : {};
+        const row = [new Date().toISOString(), JSON.stringify(body)];
+        if (process.env.APPS_SCRIPT_DEPLOYMENT) {
+          const qs = new URLSearchParams({ cmd: "add", row: JSON.stringify(row) });
+          await fetch(`${process.env.APPS_SCRIPT_DEPLOYMENT}?${qs.toString()}`);
+        }
+        return ok(res, { ok: true });
+      }
+      case "GET /api/donors":
+        return ok(res, { ok: true, donors: [] });
       default:
         return fail(res, 404, "Not found");
     }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /mags
+Allow: /site
+Sitemap: https://mags-assistant.vercel.app/site/sitemap.xml

--- a/public/site/404.html
+++ b/public/site/404.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Not Found - Mags</title>
+  <meta name="description" content="Page not found" />
+  <link rel="canonical" href="https://mags-assistant.vercel.app/site/404.html" />
+  <meta property="og:title" content="Not Found - Mags" />
+  <meta property="og:description" content="Page not found" />
+  <link rel="stylesheet" href="/brand.css" />
+</head>
+<body>
+  <h1>404 - Not Found</h1>
+  <p>Sorry, we can't find that page.</p>
+</body>
+</html>

--- a/public/site/500.html
+++ b/public/site/500.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Error - Mags</title>
+  <meta name="description" content="Server error" />
+  <link rel="canonical" href="https://mags-assistant.vercel.app/site/500.html" />
+  <meta property="og:title" content="Error - Mags" />
+  <meta property="og:description" content="Server error" />
+  <link rel="stylesheet" href="/brand.css" />
+</head>
+<body>
+  <h1>500 - Server Error</h1>
+  <p>Something went wrong.</p>
+</body>
+</html>

--- a/public/site/contact/index.html
+++ b/public/site/contact/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Contact - Mags</title>
+  <meta name="description" content="Contact us" />
+  <link rel="canonical" href="https://mags-assistant.vercel.app/site/contact/" />
+  <meta property="og:title" content="Contact - Mags" />
+  <meta property="og:description" content="Contact us" />
+  <meta property="og:url" content="https://mags-assistant.vercel.app/site/contact/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="stylesheet" href="/brand.css" />
+</head>
+<body>
+  <h1>Contact</h1>
+  <form action="mailto:hello@example.com" method="post" enctype="text/plain">
+    <label>Email: <input type="email" name="email" required></label>
+    <label>Message: <textarea name="message" required></textarea></label>
+    <button type="submit">Send</button>
+  </form>
+  <button onclick="navigator.clipboard.writeText('hello@example.com')">Copy email</button>
+</body>
+</html>

--- a/public/site/donate/index.html
+++ b/public/site/donate/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Donate - Mags</title>
+  <meta name="description" content="Support Mags" />
+  <link rel="canonical" href="https://mags-assistant.vercel.app/site/donate/" />
+  <meta property="og:title" content="Donate - Mags" />
+  <meta property="og:description" content="Support Mags" />
+  <meta property="og:url" content="https://mags-assistant.vercel.app/site/donate/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="stylesheet" href="/brand.css" />
+</head>
+<body>
+  <h1>Donate</h1>
+  <p>Choose an amount to support us.</p>
+  <button>$5</button>
+  <button>$10</button>
+  <button>$20</button>
+  <section id="donor-wall" aria-label="Donor Wall">
+    <h2>Donor Wall</h2>
+    <ul></ul>
+  </section>
+  <script>
+    const key = localStorage.getItem('magsKey');
+    fetch('/api/donors', key ? {headers:{'x-mags-key':key}} : {}).then(r=>r.json()).then(data=>{
+      const list=document.querySelector('#donor-wall ul');
+      if(Array.isArray(data.donors)){
+        data.donors.forEach(d=>{
+          const li=document.createElement('li');
+          li.textContent=d.name||'Anonymous';
+          list.appendChild(li);
+        });
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Mags Home</title>
+  <meta name="description" content="Welcome to Mags" />
+  <link rel="canonical" href="https://mags-assistant.vercel.app/site/" />
+  <meta property="og:title" content="Mags Home" />
+  <meta property="og:description" content="Welcome to Mags" />
+  <meta property="og:url" content="https://mags-assistant.vercel.app/site/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="stylesheet" href="/brand.css" />
+</head>
+<body>
+  <header>
+    <h1>Mags</h1>
+    <p>Your source for soulful goods</p>
+  </header>
+  <main>
+    <section aria-label="Featured products">
+      <h2>Featured Products</h2>
+      <ul>
+        <li><a href="/site/products/sample-product.html">Sample Product</a></li>
+      </ul>
+    </section>
+    <nav>
+      <a href="/site/products/">Products</a>
+      <a href="/site/quiz/">Soul Quiz</a>
+      <a href="/site/donate/">Donate</a>
+      <a href="/site/contact/">Contact</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/public/site/products/index.html
+++ b/public/site/products/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Products - Mags</title>
+  <meta name="description" content="Our products" />
+  <link rel="canonical" href="https://mags-assistant.vercel.app/site/products/" />
+  <meta property="og:title" content="Products - Mags" />
+  <meta property="og:description" content="Our products" />
+  <meta property="og:url" content="https://mags-assistant.vercel.app/site/products/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="stylesheet" href="/brand.css" />
+</head>
+<body>
+  <h1>Products</h1>
+  <ul>
+    <li><a href="/site/products/sample-product.html">Sample Product</a></li>
+  </ul>
+</body>
+</html>

--- a/public/site/products/sample-product.html
+++ b/public/site/products/sample-product.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Sample Product - Mags</title>
+  <meta name="description" content="Sample product description" />
+  <link rel="canonical" href="https://mags-assistant.vercel.app/site/products/sample-product.html" />
+  <meta property="og:title" content="Sample Product" />
+  <meta property="og:description" content="Sample product description" />
+  <meta property="og:url" content="https://mags-assistant.vercel.app/site/products/sample-product.html" />
+  <meta property="og:image" content="https://via.placeholder.com/600" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="stylesheet" href="/brand.css" />
+</head>
+<body>
+  <h1>Sample Product</h1>
+  <img src="https://via.placeholder.com/600" alt="Sample" loading="lazy" decoding="async" width="600" height="400" />
+  <p>This is a sample product.</p>
+  <p><a href="#" aria-label="Buy Sample Product">Buy</a></p>
+</body>
+</html>

--- a/public/site/quiz/index.html
+++ b/public/site/quiz/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Soul Quiz - Mags</title>
+  <meta name="description" content="Take the soul quiz" />
+  <link rel="canonical" href="https://mags-assistant.vercel.app/site/quiz/" />
+  <meta property="og:title" content="Soul Quiz - Mags" />
+  <meta property="og:description" content="Take the soul quiz" />
+  <meta property="og:url" content="https://mags-assistant.vercel.app/site/quiz/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="stylesheet" href="/brand.css" />
+</head>
+<body>
+  <h1>Soul Quiz</h1>
+  <iframe src="https://tally.so/embed/sample" width="100%" height="400" loading="lazy" title="Soul Quiz"></iframe>
+  <p>Thanks for taking the quiz!</p>
+</body>
+</html>

--- a/public/site/sitemap.xml
+++ b/public/site/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://mags-assistant.vercel.app/site/</loc></url>
+  <url><loc>https://mags-assistant.vercel.app/site/products/</loc></url>
+  <url><loc>https://mags-assistant.vercel.app/site/products/sample-product.html</loc></url>
+  <url><loc>https://mags-assistant.vercel.app/site/quiz/</loc></url>
+  <url><loc>https://mags-assistant.vercel.app/site/donate/</loc></url>
+  <url><loc>https://mags-assistant.vercel.app/site/contact/</loc></url>
+</urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,10 @@
 {
   "routes": [
-    { "src": "/api/(.*)", "dest": "/api/router.js" },
-    { "src": "/watch", "dest": "/watch.html" },
-    { "src": "/studio", "dest": "/studio.html" },
-    { "src": "/planner", "dest": "/planner.html" }
+    { "src": "^/api/(.*)$", "dest": "/api/router.js" },
+    { "src": "^/watch$", "dest": "/watch.html" },
+    { "src": "^/$", "status": 302, "headers": { "Location": "/site/" } }
+  ],
+  "headers": [
+    { "source": "/mags/(.*)", "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }] }
   ]
 }


### PR DESCRIPTION
## Summary
- add unified API router with private routes and basic webhooks
- publish static site with product and donation pages
- configure Vercel routing and robots rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a00c7fa88327ba97401da1e4fd85