### PR TITLE
feat: add voice modes and planning endpoints

### DIFF
--- a/components/MagsRunsPanel.jsx
+++ b/components/MagsRunsPanel.jsx
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'https://esm.sh/react@18';
+
+export default function MagsRunsPanel({ magsKey }) {
+  const [runs, setRuns] = useState([]);
+  const [out, setOut] = useState('');
+  async function load() {
+    const res = await fetch('/api/agent/jobs', { headers: { 'x-mags-key': magsKey } });
+    const data = await res.json();
+    setRuns(data.results || []);
+    setOut(JSON.stringify(data, null, 2));
+  }
+  useEffect(() => { load(); }, []);
+  return (
+    <div style={{border:'1px solid #ddd', padding:12, borderRadius:8, marginTop:16}}>
+      <h3>Runs</h3>
+      <button onClick={load}>Refresh</button>
+      <ul>
+        {runs.map(r => (
+          <li key={r.id}>{r.properties?.Name?.title?.[0]?.plain_text}</li>
+        ))}
+      </ul>
+      <pre style={{whiteSpace:'pre-wrap', marginTop:8}}>{out}</pre>
+    </div>
+  );
+}

--- a/components/MagsVoicePanel.jsx
+++ b/components/MagsVoicePanel.jsx
@@ -1,0 +1,84 @@
+import { useState, useRef } from 'https://esm.sh/react@18';
+
+export default function MagsVoicePanel({ magsKey }) {
+  const [mode, setMode] = useState('plan');
+  const [listening, setListening] = useState(false);
+  const [text, setText] = useState('');
+  const [plan, setPlan] = useState(null);
+  const [out, setOut] = useState('');
+  const recRef = useRef(null);
+
+  function start() {
+    if (!('webkitSpeechRecognition' in window)) {
+      alert('Speech recognition not supported');
+      return;
+    }
+    const r = new webkitSpeechRecognition();
+    r.lang = 'en-US';
+    r.continuous = false;
+    r.onresult = e => {
+      const t = e.results[0][0].transcript;
+      setText(t);
+      if (mode === 'run') runCommand(t); else planCommand(t);
+    };
+    r.onend = () => setListening(false);
+    r.start();
+    recRef.current = r;
+    setListening(true);
+  }
+
+  function stop() {
+    recRef.current && recRef.current.stop();
+    setListening(false);
+  }
+
+  async function planCommand(t) {
+    const res = await fetch('/api/agent/plan', {
+      method: 'POST',
+      headers: { 'x-mags-key': magsKey, 'content-type': 'application/json' },
+      body: JSON.stringify({ text: t })
+    });
+    const data = await res.json();
+    setPlan(data.plan);
+    setOut(JSON.stringify(data, null, 2));
+  }
+
+  async function runCommand(t) {
+    const res = await fetch('/api/agent/command', {
+      method: 'POST',
+      headers: { 'x-mags-key': magsKey, 'content-type': 'application/json' },
+      body: JSON.stringify({ text: t })
+    });
+    const data = await res.json();
+    setOut(JSON.stringify(data, null, 2));
+  }
+
+  async function approve() {
+    if (!plan) return;
+    const res = await fetch('/api/agent/run', {
+      method: 'POST',
+      headers: { 'x-mags-key': magsKey, 'content-type': 'application/json' },
+      body: JSON.stringify({ plan, text })
+    });
+    const data = await res.json();
+    setPlan(null);
+    setOut(JSON.stringify(data, null, 2));
+  }
+
+  return (
+    <div style={{border:'1px solid #ddd', padding:12, borderRadius:8, marginTop:16}}>
+      <h3>Voice Control</h3>
+      <div style={{marginBottom:8}}>
+        <label>Mode: </label>
+        <select value={mode} onChange={e=>setMode(e.target.value)}>
+          <option value="plan">Speak & Plan</option>
+          <option value="run">Speak & Run</option>
+        </select>
+      </div>
+      <button onClick={listening?stop:start}>{listening ? 'Stop' : '\uD83C\uDF99\uFE0F Start'}</button>
+      {mode==='plan' && plan && <button onClick={approve} style={{marginLeft:8}}>Approve Plan & Run</button>}
+      <div style={{marginTop:8}}><strong>Transcript:</strong> {text}</div>
+      <pre style={{whiteSpace:'pre-wrap', marginTop:8}}>{out}</pre>
+    </div>
+  );
+}

--- a/lib/agent/executor.js
+++ b/lib/agent/executor.js
@@ -1,0 +1,84 @@
+import { notion, requireEnv } from '../notion.js';
+
+async function createRun(command) {
+  const db = process.env.NOTION_DB_RUNS_ID;
+  if (!db) return null;
+  const page = await notion.pages.create({
+    parent: { database_id: db },
+    properties: {
+      Name: { title: [{ text: { content: command.slice(0, 50) } }] },
+      Status: { status: { name: 'Running' } },
+      Command: { rich_text: [{ text: { content: command } }] },
+      Started: { date: { start: new Date().toISOString() } },
+    },
+  });
+  return page.id;
+}
+
+async function appendRun(id, text) {
+  if (!id) return;
+  const page = await notion.pages.retrieve({ page_id: id });
+  const prev = page.properties?.Result?.rich_text?.map(r => r.plain_text).join('\n') || '';
+  const combined = prev ? `${prev}\n${text}` : text;
+  await notion.pages.update({
+    page_id: id,
+    properties: {
+      Result: { rich_text: [{ text: { content: combined } }] },
+    },
+  });
+}
+
+async function finishRun(id, ok) {
+  if (!id) return;
+  await notion.pages.update({
+    page_id: id,
+    properties: {
+      Status: { status: { name: ok ? 'Success' : 'Failed' } },
+      Ended: { date: { start: new Date().toISOString() } },
+    },
+  });
+}
+
+async function ensureDonor({ name, amount, frequency }) {
+  const db = requireEnv('NOTION_DB_DONORS_ID');
+  await notion.pages.create({
+    parent: { database_id: db },
+    properties: {
+      Name: { title: [{ text: { content: name } }] },
+      Amount: { number: amount },
+      Frequency: { select: { name: frequency } },
+      Status: { status: { name: 'pledged' } },
+    },
+  });
+}
+
+async function createSubpage({ title }) {
+  const hq = requireEnv('NOTION_HQ_PAGE_ID');
+  await notion.pages.create({
+    parent: { page_id: hq },
+    properties: { title: [{ type: 'text', text: { content: title } }] },
+  });
+}
+
+export async function runPlan(plan, { text }) {
+  const runId = await createRun(text);
+  try {
+    for (const step of plan.steps) {
+      if (step.tool === 'notion' && step.action === 'createDonor') {
+        await ensureDonor(step.args);
+        await appendRun(runId, `Donor ${step.args.name} added`);
+      } else if (step.tool === 'notion' && step.action === 'hqSubpage') {
+        await createSubpage(step.args);
+        await appendRun(runId, `Subpage ${step.args.title} created`);
+      } else {
+        await appendRun(runId, `Unknown step ${step.action}`);
+      }
+    }
+    await finishRun(runId, true);
+    return { runId };
+  } catch (e) {
+    await appendRun(runId, `Error: ${e.message}`);
+    await finishRun(runId, false);
+    throw e;
+  }
+}

--- a/lib/agent/planner.js
+++ b/lib/agent/planner.js
@@ -1,0 +1,21 @@
+export function planFromText(text='') {
+  const plan = { steps: [], needsViewer: false };
+  if (!text) return plan;
+  // Donor addition: "Add donor Jane Doe $50 monthly"
+  const donor = text.match(/add donor ([\w\s]+) \$?(\d+)(?: (monthly|one-time))?/i);
+  if (donor) {
+    const name = donor[1].trim();
+    const amount = Number(donor[2]);
+    const frequency = donor[3] || 'one-time';
+    plan.steps.push({ tool: 'notion', action: 'createDonor', args: { name, amount, frequency } });
+    return plan;
+  }
+  // Notion subpage: "Create a subpage X under HQ"
+  const subpage = text.match(/create (?:a )?subpage ['\"]?([^'\"]+)['\"]? under hq/i);
+  if (subpage) {
+    const title = subpage[1].trim();
+    plan.steps.push({ tool: 'notion', action: 'hqSubpage', args: { title } });
+    return plan;
+  }
+  return plan;
+}

--- a/public/mags.html
+++ b/public/mags.html
@@ -15,13 +15,17 @@
   <script type="module">
     import React from 'https://esm.sh/react@18';
     import { createRoot } from 'https://esm.sh/react-dom@18/client';
+    import MagsVoicePanel from '../components/MagsVoicePanel.jsx';
     import MagsNotionPanel from '../components/MagsNotionPanel.jsx';
     import MagsHQPanel from '../components/MagsHQPanel.jsx';
+    import MagsRunsPanel from '../components/MagsRunsPanel.jsx';
     const magsKey = localStorage.getItem('magsKey') || '';
     createRoot(document.getElementById('panel')).render(
       React.createElement(React.Fragment, null,
+        React.createElement(MagsVoicePanel, { magsKey }),
         React.createElement(MagsNotionPanel, { magsKey }),
-        React.createElement(MagsHQPanel, { magsKey })
+        React.createElement(MagsHQPanel, { magsKey }),
+        React.createElement(MagsRunsPanel, { magsKey })
       )
     );
   </script>


### PR DESCRIPTION
## Summary
- add Speak & Plan / Speak & Run voice control panel with transcript and approval flow
- expand planner/executor for Notion donor adds and HQ subpage creation with run logging
- expose /api/agent plan/command/run/jobs/logs endpoints and stub Stripe sync; update /mags admin page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898057998988327897583bcb06c0a7a