### PR TITLE
fix: queue merge + cron runner + seed endpoint

### DIFF
--- a/.github/workflows/cron-runner.yml
+++ b/.github/workflows/cron-runner.yml
@@ -1,70 +1,70 @@
 name: mags-cron
 
 on:
-  schedule: [{ cron: "*/10 * * * *" }]
-  workflow_dispatch: {}
-  repository_dispatch:
-    types: [mags-run-queue]
-
-permissions:
-  contents: read
+  workflow_dispatch:
+  schedule:
+    - cron: "*/15 * * * *"  # every 15 minutes
 
 jobs:
-  run-queue:
+  run:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      API_BASE: ${{ secrets.API_BASE }}
+      WORKER_KEY: ${{ secrets.WORKER_KEY }}
     steps:
-      - name: Install tools
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y jq curl
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Run job
-        id: runjob
+      - name: Claim job
+        id: claim
         shell: bash
-        env:
-          API_BASE: ${{ secrets.API_BASE }}
-          WORKER_KEY: ${{ secrets.WORKER_KEY }}
         run: |
           set -euo pipefail
-          # claim
-          curl -s -X POST "$API_BASE/api/queue/claim" \
-            -H "X-Worker-Key: $WORKER_KEY" -H "content-type: application/json" \
-            -d '{}' > job.json
-          ID=$(jq -r '.id // empty' job.json || true)
-          echo "ID=$ID"
-          if [ -z "${ID:-}" ]; then
-            echo "No jobs in queue; exiting 0"
+          echo "Claiming next job from $API_BASE ..."
+          CLAIM_RESP=$(curl -sS -X POST "$API_BASE/api/queue/claim" \
+            -H "X-Worker-Key: $WORKER_KEY" \
+            -H "content-type: application/json" \
+            -d '{}' )
+          echo "$CLAIM_RESP" | tee job.json
+
+          if jq -e '.id' job.json >/dev/null 2>&1; then
+            ID=$(jq -r '.id' job.json)
+            echo "ID=$ID"
+            echo "nojob=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No jobs in queue or invalid JSON; exiting 0"
             echo "nojob=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Here is where you'd actually do the work; we just echo payload for now.
-          jq -r '.payload[0].plain_text // empty' job.json > run.log 2>/dev/null || true
-          echo "nojob=false" >> "$GITHUB_OUTPUT"
+      - name: Run job (demo)
+        if: steps.claim.outputs.nojob == 'false'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # TODO: replace with real worker logic; for now log payload
+          jq -r '.payload // empty' job.json || true
 
       - name: Mark complete
-        if: steps.runjob.outputs.nojob == 'false'
+        if: steps.claim.outputs.nojob == 'false' && success()
         shell: bash
-        env:
-          API_BASE: ${{ secrets.API_BASE }}
-          WORKER_KEY: ${{ secrets.WORKER_KEY }}
         run: |
           set -euo pipefail
           ID=$(jq -r '.id' job.json)
-          curl -s -X POST "$API_BASE/api/queue/complete" \
-            -H "X-Worker-Key: $WORKER_KEY" -H "content-type: application/json" \
+          curl -sS -X POST "$API_BASE/api/queue/complete" \
+            -H "X-Worker-Key: $WORKER_KEY" \
+            -H "content-type: application/json" \
             -d "{\"id\":\"$ID\"}" >/dev/null
 
       - name: Mark failed
-        if: failure() && steps.runjob.outputs.nojob == 'false'
+        if: steps.claim.outputs.nojob == 'false' && failure()
         shell: bash
-        env:
-          API_BASE: ${{ secrets.API_BASE }}
-          WORKER_KEY: ${{ secrets.WORKER_KEY }}
         run: |
           set -euo pipefail
           ID=$(jq -r '.id' job.json)
-          ERR=$(cat run.log 2>/dev/null || echo "runner failed")
-          curl -s -X POST "$API_BASE/api/queue/fail" \
-            -H "X-Worker-Key: $WORKER_KEY" -H "content-type: application/json" \
-            -d '{"id":"'"$ID"'","error":'"$(jq -Rn --arg e "$ERR" '$e')"'}' >/dev/null
+          ERR="runner failed"
+          curl -sS -X POST "$API_BASE/api/queue/fail" \
+            -H "X-Worker-Key: $WORKER_KEY" \
+            -H "content-type: application/json" \
+            -d "{\"id\":\"$ID\",\"error\":$(jq -Rn --arg e \"$ERR\" '$e')}" >/dev/null

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -13,30 +13,25 @@ export function requireEnv(name) {
 const rt = (s) => ({ rich_text: [{ text: { content: s } }] });
 const getText = (prop) => prop?.rich_text?.[0]?.plain_text || '';
 
-export async function enqueueTask({ task, payload, runAt, callback }) {
-  const jobId = randomUUID();
+export async function enqueueTask({ jobId, payload }) {
   const props = {
-    Task: { title: [{ text: { content: task } }] },
-    Status: { select: { name: 'Queued' } },
+    Title: { title: [{ type: 'text', text: { content: `Task ${jobId}` } }] },
     JobId: rt(jobId),
-    Attempts: { number: 0 },
-    Locked: { checkbox: false },
+    Payload: {
+      rich_text: [
+        {
+          type: 'text',
+          text: { content: JSON.stringify(payload).slice(0, 1900) },
+        },
+      ],
+    },
+    Status: { select: { name: 'Queued' } },
   };
-  if (payload !== undefined) {
-    const text =
-      typeof payload === 'string' ? payload : JSON.stringify(payload);
-    props['Payload'] = rt(text.slice(0, 1900));
-  }
-  if (runAt)
-    props['Run At'] = {
-      date: { start: new Date(runAt).toISOString() },
-    };
-  if (callback) props['Callback'] = { url: callback };
   const page = await notion.pages.create({
     parent: { database_id: DB },
     properties: props,
   });
-  return { jobId, notionId: page.id };
+  return page;
 }
 
 export async function claimNextTask() {
@@ -75,12 +70,18 @@ export async function claimNextTask() {
       ...(existing ? {} : { JobId: rt(jobId) }),
     },
   });
-  return {
-    id: jobId,
-    notionId: page.id,
-    payload: props.Payload?.rich_text ?? [],
-    callback: props.Callback?.url || null,
-  };
+  return page;
+}
+
+export function readTask(page) {
+  const props = page.properties || {};
+  const jobId = getText(props.JobId) || page.id;
+  let payload = {};
+  try {
+    const raw = getText(props.Payload);
+    payload = raw ? JSON.parse(raw) : {};
+  } catch {}
+  return { id: jobId, payload };
 }
 
 async function findByJobId(jobId) {


### PR DESCRIPTION
## Summary
- add cron workflow to regularly claim jobs and mark completion or failure
- secure RPA routes and implement enqueue/seed endpoints for queue
- update Notion helpers to persist JobId and parse claimed tasks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898bf70b3188327b19adcc9ddf7dabd