### PR TITLE
feat: seed Maggie job queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,21 @@ Automated jobs are processed by a GitHub Actions workflow located at `.github/wo
 - **Endpoints:** the runner claims jobs from `/api/queue/claim`, runs them via `/api/queue/run`, and marks them done with `/api/queue/complete`.
 
 The current schedule runs every 10 minutes.
+
+## Maggie Job Queue
+
+Automated jobs for Maggie are tracked in a Notion database named **Maggie Job Queue** under the HQ page.
+
+### Required environment variables
+
+- `NOTION_TOKEN` – Notion internal integration token
+- `NOTION_HQ_PAGE_ID` – parent page where the queue database lives
+- `NOTION_QUEUE_DB` – database ID of "Maggie Job Queue" (created on first seed)
+
+### Reseed
+
+To recreate the database and seed the initial job, call:
+
+```sh
+curl -X POST "$API_BASE/api/queue/seed" -H "x-mags-key: $CRON_SECRET"
+```

--- a/lib/env.js
+++ b/lib/env.js
@@ -2,6 +2,7 @@ export const env = {
   API_BASE: process.env.API_BASE,
   WORKER_KEY: process.env.WORKER_KEY,
   MAGS_KEY: process.env.MAGS_KEY,
+  CRON_SECRET: process.env.CRON_SECRET,
   NOTION_TOKEN: process.env.NOTION_TOKEN,
   NOTION_DATABASE_ID: process.env.NOTION_DATABASE_ID,
   NOTION_INBOX_PAGE_ID: process.env.NOTION_INBOX_PAGE_ID,
@@ -9,6 +10,7 @@ export const env = {
   BROWSERLESS_API_KEY: process.env.BROWSERLESS_API_KEY,
   NOTION_DB_RUNS_ID: process.env.NOTION_DB_RUNS_ID,
   NOTION_QUEUE_DB_ID: process.env.NOTION_QUEUE_DB_ID,
+  NOTION_QUEUE_DB: process.env.NOTION_QUEUE_DB,
 };
 
 export function requireEnv(name) {

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -13,6 +13,70 @@ export function requireEnv(name) {
 const rt = (s) => ({ rich_text: [{ text: { content: s } }] });
 const getText = (prop) => prop?.rich_text?.[0]?.plain_text || '';
 
+export async function ensureQueueDb({ parentPageId }) {
+  const title = 'Maggie Job Queue';
+  const search = await notion.search({
+    query: title,
+    filter: { property: 'object', value: 'database' },
+    page_size: 50,
+  });
+  const existing = search.results.find(
+    (d) => d.parent?.page_id === parentPageId && d.title?.[0]?.plain_text === title
+  );
+  if (existing) return { databaseId: existing.id };
+  const db = await notion.databases.create({
+    parent: { page_id: parentPageId },
+    title: [{ type: 'text', text: { content: title } }],
+    properties: {
+      'Job Name': { title: {} },
+      Status: {
+        select: {
+          options: [
+            { name: 'Pending', color: 'yellow' },
+            { name: 'In Progress', color: 'blue' },
+            { name: 'Done', color: 'green' },
+            { name: 'Failed', color: 'red' },
+          ],
+        },
+      },
+      Parameters: { rich_text: {} },
+      'Requested By': { people: {} },
+      'Created Date': { created_time: {} },
+      'Result / Notes': { rich_text: {} },
+    },
+  });
+  return { databaseId: db.id };
+}
+
+export async function enqueueJob({
+  databaseId,
+  name,
+  parameters,
+  requestedByEmail,
+}) {
+  let people = [];
+  if (requestedByEmail) {
+    try {
+      const users = await notion.users.list({ page_size: 100 });
+      const user = users.results.find(
+        (u) => u.type === 'person' && u.person?.email === requestedByEmail
+      );
+      if (user) people.push({ id: user.id });
+    } catch {}
+  }
+  const props = {
+    'Job Name': { title: [{ type: 'text', text: { content: name } }] },
+    Status: { select: { name: 'Pending' } },
+    Parameters: { rich_text: [{ type: 'text', text: { content: parameters } }] },
+    ...(people.length ? { 'Requested By': { people } } : {}),
+  };
+  const page = await notion.pages.create({
+    parent: { database_id: databaseId },
+    properties: props,
+  });
+  return { id: page.id };
+}
+
 export async function enqueueTask({ jobId, payload }) {
   const props = {
     Title: { title: [{ type: 'text', text: { content: `Task ${jobId}` } }] },


### PR DESCRIPTION
## Summary
- add Notion helpers to ensure the Maggie Job Queue database and enqueue jobs
- create `/api/queue/seed` endpoint to initialize the queue with first job
- document Maggie Job Queue setup and required env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898da327efc8327a55fd9c8d181c22d