### PR TITLE
feat: add email and social stubs

### DIFF
--- a/apps/api/lib/email.ts
+++ b/apps/api/lib/email.ts
@@ -1,0 +1,23 @@
+export function gmailEnabled() {
+  return !!(
+    process.env.GOOGLE_CLIENT_ID &&
+    process.env.GOOGLE_CLIENT_SECRET &&
+    process.env.GOOGLE_REDIRECT_URI
+  );
+}
+
+export async function watchForEmail() {
+  if (!gmailEnabled()) {
+    return { ok: false, message: 'email disabled' };
+  }
+  // Stub implementation; real Gmail polling would go here.
+  return { ok: true, checked: 0 };
+}
+
+export async function sendApprovedDrafts() {
+  if (!gmailEnabled()) {
+    return { ok: false, message: 'email disabled' };
+  }
+  // Stub implementation; real Gmail send logic would go here.
+  return { ok: true, sent: 0 };
+}

--- a/apps/api/lib/outreach.ts
+++ b/apps/api/lib/outreach.ts
@@ -1,0 +1,9 @@
+export async function seedOutreach() {
+  // Stub: would research target and draft email.
+  return { ok: true, drafted: false };
+}
+
+export async function runOutreach() {
+  // Stub: would iterate over targets and call seedOutreach for each.
+  return { ok: true, processed: 0 };
+}

--- a/apps/api/lib/social.ts
+++ b/apps/api/lib/social.ts
@@ -1,0 +1,21 @@
+export function tiktokEnabled() {
+  return !!(
+    process.env.TIKTOK_ACCESS_TOKEN &&
+    process.env.TIKTOK_CLIENT_KEY &&
+    process.env.TIKTOK_CLIENT_SECRET
+  );
+}
+
+export async function scheduleClip() {
+  // Stub: scheduling logic would choose optimal time and update Notion.
+  return { ok: true, scheduled: false };
+}
+
+export async function postDueClips() {
+  if (!tiktokEnabled()) {
+    // Export-only mode; nothing posted.
+    return { ok: true, posted: 0, exportOnly: true };
+  }
+  // Stub implementation; real TikTok posting would go here.
+  return { ok: true, posted: 0 };
+}

--- a/apps/api/lib/tasks/email-watch.ts
+++ b/apps/api/lib/tasks/email-watch.ts
@@ -1,0 +1,11 @@
+import { watchForEmail } from "../email";
+import type { TaskResult } from "./index";
+
+export async function emailWatch(): Promise<TaskResult> {
+  try {
+    const r = await watchForEmail();
+    return { name: "email.watch", ok: r.ok !== false, msg: r.message };
+  } catch (err: any) {
+    return { name: "email.watch", ok: false, msg: err?.message || String(err) };
+  }
+}

--- a/apps/api/lib/tasks/index.ts
+++ b/apps/api/lib/tasks/index.ts
@@ -3,6 +3,8 @@ import { syncHQ } from "./notion-sync";
 import { refreshSocialPlanner } from "./social-planner";
 import { sweepReminders } from "./reminders";
 import { triageInbox } from "./inbox";
+import { emailWatch } from "./email-watch";
+import { socialPostDue } from "./social-post";
 
 export type TaskResult = { name: string; ok: boolean; msg?: string };
 export type TaskFn = () => Promise<TaskResult>;
@@ -12,6 +14,8 @@ export const tasks: Record<string, TaskFn> = {
   "social.refresh_planner": refreshSocialPlanner,
   "ops.sweep_reminders": sweepReminders,
   "ops.triage_inbox": triageInbox,
+  "email.watch": emailWatch,
+  "social.post_due": socialPostDue,
 };
 
 const taskFlags: Record<string, string> = {
@@ -19,6 +23,8 @@ const taskFlags: Record<string, string> = {
   "social.refresh_planner": "TASK_SOCIAL_REFRESH",
   "ops.sweep_reminders": "TASK_REMINDERS_SWEEP",
   "ops.triage_inbox": "TASK_INBOX_TRIAGE",
+  "email.watch": "TASK_EMAIL_WATCH",
+  "social.post_due": "TASK_SOCIAL_POST_DUE",
 };
 
 export async function runTasks(selected?: string[]) {

--- a/apps/api/lib/tasks/social-post.ts
+++ b/apps/api/lib/tasks/social-post.ts
@@ -1,0 +1,11 @@
+import { postDueClips } from "../social";
+import type { TaskResult } from "./index";
+
+export async function socialPostDue(): Promise<TaskResult> {
+  try {
+    const r = await postDueClips();
+    return { name: "social.post_due", ok: r.ok !== false, msg: r.exportOnly ? "export" : undefined };
+  } catch (err: any) {
+    return { name: "social.post_due", ok: false, msg: err?.message || String(err) };
+  }
+}

--- a/apps/api/src/routes/email/send.ts
+++ b/apps/api/src/routes/email/send.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sendApprovedDrafts } from "../../../lib/email";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const result = await sendApprovedDrafts();
+  const status = result.ok === false ? 501 : 200;
+  return NextResponse.json(result, { status });
+}

--- a/apps/api/src/routes/email/watch.ts
+++ b/apps/api/src/routes/email/watch.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from "next/server";
+import { watchForEmail } from "../../../lib/email";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const result = await watchForEmail();
+  const status = result.ok === false ? 501 : 200;
+  return NextResponse.json(result, { status });
+}

--- a/apps/api/src/routes/ops/diag.ts
+++ b/apps/api/src/routes/ops/diag.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+import { gmailEnabled } from "../../../lib/email";
+import { tiktokEnabled } from "../../../lib/social";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const enabled = {
+    gmail: gmailEnabled(),
+    resend: !!process.env.RESEND_API_KEY,
+    tiktok: tiktokEnabled(),
+  };
+  return NextResponse.json({ ok: true, enabled });
+}

--- a/apps/api/src/routes/outreach/run.ts
+++ b/apps/api/src/routes/outreach/run.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runOutreach } from "../../../lib/outreach";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const result = await runOutreach();
+  return NextResponse.json(result);
+}

--- a/apps/api/src/routes/outreach/seed.ts
+++ b/apps/api/src/routes/outreach/seed.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+import { seedOutreach } from "../../../lib/outreach";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const result = await seedOutreach();
+  return NextResponse.json(result);
+}

--- a/apps/api/src/routes/social/post-due.ts
+++ b/apps/api/src/routes/social/post-due.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from "next/server";
+import { postDueClips } from "../../../lib/social";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const result = await postDueClips();
+  const status = result.ok === false ? 501 : 200;
+  return NextResponse.json(result, { status });
+}

--- a/apps/api/src/routes/social/schedule.ts
+++ b/apps/api/src/routes/social/schedule.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+import { scheduleClip } from "../../../lib/social";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const result = await scheduleClip();
+  return NextResponse.json(result);
+}


### PR DESCRIPTION
## Summary
- add stubbed Gmail utilities and endpoints for watching inbox and sending drafts
- provide social scheduling and posting stubs with TikTok export-only mode
- extend cron tasks and diagnostics to reflect email and social subsystems

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899322071988327be3bd75ed88d0be6