### PR TITLE
feat: add Telegram notify and webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@ The `/chat` interface requires the following environment variables:
 - `STRIPE_SECRET_KEY` – Stripe API key.
 - `RESEND_API_KEY` – optional; API key for sending email notifications.
 - `NOTIFY_EMAIL` – optional email address for notifications.
-- `NOTIFY_WEBHOOK` – optional Slack/Discord webhook for notifications.
 - `BRAND_PRIMARY_HEX` – optional primary color override.
 - `BRAND_SECONDARY_HEX` – optional secondary color override.
+
+## Notifications & Telegram
+
+- Required: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`
+- Optional: `RESEND_API_KEY`, `NOTIFY_EMAIL`
+- Telegram webhook URL: https://assistant.messyandmagnetic.com/api/telegram/webhook
 
 ## Scheduled Tasks (free)
 We run a free scheduler using GitHub Actions that calls `/api/cron/tick` every 15 minutes.

--- a/api/router.js
+++ b/api/router.js
@@ -70,27 +70,14 @@ async function readJson(req) {
 }
 
 async function notify(subject, message) {
-  const key = process.env.RESEND_API_KEY;
-  const to = process.env.NOTIFY_EMAIL;
-  if (!key || !to) return;
   try {
-    await fetch('https://api.resend.com/emails', {
+    await fetch(`${process.env.API_BASE ?? ''}/api/notify`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${key}`,
-      },
-      body: JSON.stringify({
-        from: 'Mags <noreply@messyandmagnetic.com>',
-        to: [to],
-        subject,
-        text: message,
-      }),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: `${subject}: ${message}` }),
     });
   } catch {}
 }
-
-export const config = { runtime: 'nodejs' };
 
 export default async function handler(req, res) {
   const { method, url } = req;

--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -1,41 +1,43 @@
-import { NextRequest } from 'next/server';
-
-async function sendEmail(title: string, message: string, links?: any[]) {
-  const key = process.env.RESEND_API_KEY;
-  const to = process.env.NOTIFY_EMAIL;
-  if (!key || !to) return;
-  await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${key}`,
-    },
-    body: JSON.stringify({
-      from: 'Mags <noreply@messyandmagnetic.com>',
-      to: [to],
-      subject: title,
-      text: `${message}\n${links?.map((l) => l).join('\n') || ''}`,
-    }),
-  });
-}
-
-async function sendWebhook(title: string, message: string, links?: any[]) {
-  const url = process.env.NOTIFY_WEBHOOK;
-  if (!url) return;
-  await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title, message, links }),
-  });
-}
+import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
-  const { level = 'info', title, message, links } = await req.json();
-  await Promise.all([
-    sendEmail(title, message, links),
-    sendWebhook(title, message, links),
-  ]);
-  return new Response(JSON.stringify({ ok: true, level }), {
-    headers: { 'Content-Type': 'application/json' },
-  });
+  try {
+    const { text = '', html } = await req.json();
+    const tgToken = process.env.TELEGRAM_BOT_TOKEN;
+    const tgChat = process.env.TELEGRAM_CHAT_ID;
+    const resendKey = process.env.RESEND_API_KEY;
+    const notifyEmail = process.env.NOTIFY_EMAIL;
+
+    const tasks: Promise<any>[] = [];
+    const plain = text || (html ? html.replace(/<[^>]+>/g, '').slice(0, 4000) : '');
+
+    if (tgToken && tgChat) {
+      tasks.push(fetch(`https://api.telegram.org/bot${tgToken}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: tgChat, text: plain })
+      }));
+    }
+
+    if (resendKey && notifyEmail) {
+      tasks.push(fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${resendKey}`
+        },
+        body: JSON.stringify({
+          from: 'Mags <mags@messyandmagnetic.com>',
+          to: [notifyEmail],
+          subject: 'Mags Notification',
+          html: html ?? `<pre>${plain}</pre>`
+        })
+      }));
+    }
+
+    await Promise.all(tasks);
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e?.message ?? 'notify-failed' }, { status: 500 });
+  }
 }

--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+async function sendTelegram(text: string) {
+  const token = process.env.TELEGRAM_BOT_TOKEN!;
+  const chat = process.env.TELEGRAM_CHAT_ID!;
+  await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chat, text }),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const update = await req.json();
+    const allowed = process.env.TELEGRAM_CHAT_ID;
+    const msg = update.message ?? update.edited_message;
+    const chatId = String(msg?.chat?.id ?? '');
+    const text: string = msg?.text ?? '';
+
+    if (!text || !allowed || chatId !== String(allowed)) {
+      return NextResponse.json({ ok: true });
+    }
+
+    const res = await fetch(`${process.env.API_BASE ?? ''}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: [{ role: 'user', content: text }] })
+    });
+    const reply = await res.text();
+
+    await sendTelegram(reply || 'Okay!');
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ ok: true });
+  }
+}

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -11,25 +11,41 @@ function checkDomain(url) {
   }
 }
 
+async function notify(text) {
+  try {
+    await fetch(`${process.env.API_BASE ?? ''}/api/notify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+  } catch {}
+}
+
 export async function stripe_syncFromTracker(args = '') {
   if (env.DRY_RUN) {
     return 'dry-run: stripe.syncFromTracker';
   }
-  return `synced 1 product${args ? ' with ' + args : ''}`;
+  const msg = `synced 1 product${args ? ' with ' + args : ''}`;
+  await notify(`Stripe syncFromTracker: ${args || '1 product'}`);
+  return msg;
 }
 
 export async function notion_createTable(args = '') {
   if (env.DRY_RUN) {
     return 'dry-run: notion.createTable';
   }
-  return `created table ${args}`;
+  const msg = `created table ${args}`;
+  await notify(`Notion table created: ${args}`);
+  return msg;
 }
 
 export async function notion_appendPage(args = '') {
   if (env.DRY_RUN) {
     return 'dry-run: notion.appendPage';
   }
-  return `appended page ${args}`;
+  const msg = `appended page ${args}`;
+  await notify(`Notion page appended: ${args}`);
+  return msg;
 }
 
 export async function images_generate(args = '') {

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -31,10 +31,11 @@ export async function createNotionTask({ title, details, status }: { title: stri
 }
 
 export async function notify({ level, title, message, links }: { level: string; title: string; message: string; links?: any[] }) {
+  const text = `[${level}] ${title}: ${message}${links?.length ? ' ' + links.join(' ') : ''}`;
   await fetch('/api/notify', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ level, title, message, links }),
+    body: JSON.stringify({ text }),
   });
   return { ok: true };
 }

--- a/scripts/notify-test.http
+++ b/scripts/notify-test.http
@@ -1,0 +1,15 @@
+### Local
+POST http://localhost:3000/api/notify
+Content-Type: application/json
+
+{
+  "text": "hello from notify-test"
+}
+
+### Preview
+POST https://mags-assistant.vercel.app/api/notify
+Content-Type: application/json
+
+{
+  "text": "hello from notify-test"
+}


### PR DESCRIPTION
## Summary
- add unified /api/notify sending to Telegram and Resend
- support Telegram inbound webhook for two-way chat
- post cron and handler events to /api/notify and document setup

## Testing
- `npm test`

## Screenshots
- ![notify message](UPLOAD_NOTIFY_SCREENSHOT_URL)
- ![telegram chat](UPLOAD_CHAT_SCREENSHOT_URL)

## Links
- [cron notify](https://github.com/messyandmagnetic/mags-assistant/blob/65e01ff3be7e5282ac4605c8d9f0d42f81c1fe59/apps/api/src/routes/cron/tick.ts#L36-L39)
- [Stripe/Notion handlers](https://github.com/messyandmagnetic/mags-assistant/blob/65e01ff3be7e5282ac4605c8d9f0d42f81c1fe59/lib/handlers.js#L24-L48)


------
https://chatgpt.com/codex/tasks/task_e_689935f590d88327a60dafb689206437