### PR TITLE
Add fallback ops workflow and scripts

### DIFF
--- a/.github/workflows/ops-fallback.yml
+++ b/.github/workflows/ops-fallback.yml
@@ -1,0 +1,48 @@
+name: mags-ops-fallback
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Task to run"
+        required: true
+        type: choice
+        options:
+          - sync-stripe-from-notion
+          - export-notion
+        default: sync-stripe-from-notion
+      dry:
+        description: "Dry run?"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+      - run: npm ci
+      - name: Export Notion (optional)
+        if: ${{ inputs.task == 'export-notion' }}
+        run: npx tsx scripts/notion_export.ts
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          PRODUCTS_DB_ID: ${{ secrets.PRODUCTS_DB_ID }}
+      - name: Sync Stripe from Notion
+        if: ${{ inputs.task == 'sync-stripe-from-notion' }}
+        run: npx tsx scripts/stripe_sync.ts ${{ inputs.dry && '--dry' || '' }}
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          PRODUCTS_DB_ID: ${{ secrets.PRODUCTS_DB_ID }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      - name: Announce summary (optional)
+        if: always()
+        run: npx tsx scripts/announce.ts
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/README.md
+++ b/README.md
@@ -84,3 +84,20 @@ To recreate the database and seed the initial job, call:
 ```sh
 curl -X POST "$API_BASE/api/queue/seed" -H "x-mags-key: $CRON_SECRET"
 ```
+
+## Fallback Ops
+
+Manual Stripe/Notion tasks can run via GitHub Actions when Mags is offline.
+
+### Required secrets
+Set these in Repo → Settings → Secrets and variables → Actions:
+- `NOTION_TOKEN` – internal Notion integration
+- `PRODUCTS_DB_ID` – ID of the "Stripe Product Tracker" database
+- `STRIPE_SECRET_KEY`
+- optional: `RESEND_API_KEY`, `NOTIFY_EMAIL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`
+
+### Run
+1. Open **GitHub → Actions** and select **mags-ops-fallback**.
+2. Click **Run workflow**.
+3. Choose a task (e.g. `sync-stripe-from-notion`) and start with **Dry run** = true.
+4. Inspect the logs, then re-run with **Dry run** = false to apply changes.

--- a/scripts/announce.ts
+++ b/scripts/announce.ts
@@ -1,0 +1,40 @@
+const summary = process.argv.slice(2).join(' ') || 'Ops task completed.';
+
+async function sendEmail(summary: string) {
+  const { RESEND_API_KEY, NOTIFY_EMAIL } = process.env as Record<string, string>;
+  if (!RESEND_API_KEY || !NOTIFY_EMAIL) return;
+  await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: 'Mags Ops <onboarding@resend.dev>',
+      to: NOTIFY_EMAIL,
+      subject: 'Mags Ops Fallback',
+      text: summary,
+    }),
+  });
+  console.log('Sent email to', NOTIFY_EMAIL);
+}
+
+async function sendTelegram(summary: string) {
+  const { TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID } = process.env as Record<string, string>;
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return;
+  await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: TELEGRAM_CHAT_ID, text: summary }),
+  });
+  console.log('Sent Telegram message');
+}
+
+async function main() {
+  await Promise.all([sendEmail(summary), sendTelegram(summary)]);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/notion_export.ts
+++ b/scripts/notion_export.ts
@@ -1,0 +1,37 @@
+import { Client } from '@notionhq/client';
+import fs from 'fs/promises';
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+const databaseId = process.env.PRODUCTS_DB_ID;
+
+if (!databaseId) {
+  console.error('Missing PRODUCTS_DB_ID');
+  process.exit(1);
+}
+
+async function fetchPages() {
+  const pages: any[] = [];
+  let cursor: string | undefined = undefined;
+  while (true) {
+    const res = await notion.databases.query({
+      database_id: databaseId!,
+      start_cursor: cursor,
+    });
+    pages.push(...res.results);
+    if (!res.has_more) break;
+    cursor = res.next_cursor || undefined;
+  }
+  return pages;
+}
+
+async function main() {
+  const pages = await fetchPages();
+  await fs.mkdir('tmp', { recursive: true });
+  await fs.writeFile('tmp/notion-products.json', JSON.stringify(pages, null, 2));
+  console.log(`Exported ${pages.length} rows to tmp/notion-products.json`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/stripe_sync.ts
+++ b/scripts/stripe_sync.ts
@@ -1,0 +1,176 @@
+import { Client } from '@notionhq/client';
+import Stripe from 'stripe';
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2023-10-16',
+});
+
+const databaseId = process.env.PRODUCTS_DB_ID;
+const dry = process.argv.includes('--dry');
+
+if (!databaseId) {
+  console.error('Missing PRODUCTS_DB_ID');
+  process.exit(1);
+}
+
+interface NotionProduct {
+  id: string;
+  name: string;
+  description?: string;
+  active: boolean;
+  imageUrl?: string;
+  stripeProductId?: string;
+  stripePriceId?: string;
+  unitAmount?: number;
+  currency: string;
+  metadata: Record<string, string>;
+  taxBehavior?: Stripe.ProductCreateParams.TaxBehavior;
+}
+
+async function fetchPages() {
+  const pages: any[] = [];
+  let cursor: string | undefined = undefined;
+  while (true) {
+    const res = await notion.databases.query({
+      database_id: databaseId!,
+      start_cursor: cursor,
+    });
+    pages.push(...res.results);
+    if (!res.has_more) break;
+    cursor = res.next_cursor || undefined;
+  }
+  return pages;
+}
+
+function parseMetadata(raw?: string): Record<string, string> {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const out: Record<string, string> = {};
+    raw.split(',').forEach((kv) => {
+      const [k, v] = kv.split('=');
+      if (k && v) out[k.trim()] = v.trim();
+    });
+    return out;
+  }
+}
+
+function parsePage(page: any): NotionProduct {
+  const props = page.properties;
+  const name = props.Name?.title?.[0]?.plain_text || 'Unnamed';
+  const description = props.Description?.rich_text?.[0]?.plain_text;
+  const active = props.Active?.checkbox ?? true;
+  const imageUrl = props['Image URL']?.url || undefined;
+  const stripeProductId = props['Stripe Product ID']?.rich_text?.[0]?.plain_text;
+  const stripePriceId = props['Stripe Price ID']?.rich_text?.[0]?.plain_text;
+  const unitAmount = props['Unit Amount']?.number || undefined;
+  const currency = props.Currency?.select?.name || 'usd';
+  const metadata = parseMetadata(props.Metadata?.rich_text?.[0]?.plain_text);
+  const taxBehavior = props['Tax Behavior']?.select?.name as
+    | Stripe.ProductCreateParams.TaxBehavior
+    | undefined;
+  return {
+    id: page.id,
+    name,
+    description,
+    active,
+    imageUrl,
+    stripeProductId,
+    stripePriceId,
+    unitAmount,
+    currency,
+    metadata,
+    taxBehavior,
+  };
+}
+
+async function updateNotion(pageId: string, updates: Record<string, string>) {
+  await notion.pages.update({
+    page_id: pageId,
+    properties: Object.fromEntries(
+      Object.entries(updates).map(([k, v]) => [k, { rich_text: [{ type: 'text', text: { content: v } }] }])
+    ),
+  });
+}
+
+async function syncProduct(p: NotionProduct) {
+  let productId = p.stripeProductId;
+  let priceId = p.stripePriceId;
+
+  if (productId) {
+    if (dry) {
+      console.log(`[dry] update product ${productId}`);
+    } else {
+      const existing = await stripe.products.retrieve(productId);
+      const images = p.imageUrl ? [p.imageUrl] : existing.images;
+      await stripe.products.update(productId, {
+        name: p.name,
+        description: p.description,
+        active: p.active,
+        images,
+        tax_behavior: p.taxBehavior,
+        metadata: p.metadata,
+      });
+    }
+  } else {
+    if (dry) {
+      console.log('[dry] create product for', p.name);
+      productId = 'new_product_id';
+    } else {
+      const created = await stripe.products.create({
+        name: p.name,
+        description: p.description,
+        active: p.active,
+        images: p.imageUrl ? [p.imageUrl] : undefined,
+        tax_behavior: p.taxBehavior,
+        metadata: p.metadata,
+      });
+      productId = created.id;
+      await updateNotion(p.id, { 'Stripe Product ID': productId });
+    }
+  }
+
+  if (priceId) {
+    if (dry) {
+      console.log(`[dry] update price ${priceId} metadata`);
+    } else {
+      await stripe.prices.update(priceId, { metadata: p.metadata });
+    }
+  } else if (p.unitAmount) {
+    if (dry) {
+      console.log('[dry] create price');
+      priceId = 'new_price_id';
+    } else {
+      const price = await stripe.prices.create({
+        currency: p.currency,
+        unit_amount: p.unitAmount,
+        product: productId!,
+        tax_behavior: p.taxBehavior,
+        metadata: p.metadata,
+      });
+      priceId = price.id;
+      await updateNotion(p.id, { 'Stripe Price ID': priceId });
+    }
+  }
+
+  if (!dry && productId && priceId) {
+    await stripe.products.update(productId, { default_price: priceId });
+  } else if (dry && productId && priceId) {
+    console.log(`[dry] set default price ${priceId} on product ${productId}`);
+  }
+}
+
+async function main() {
+  const pages = await fetchPages();
+  for (const page of pages) {
+    const p = parsePage(page);
+    await syncProduct(p);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add TypeScript scripts to sync Stripe products from Notion, export DB contents, and announce results via email or Telegram
- create `mags-ops-fallback` workflow for manual Stripe/Notion tasks
- document required secrets and usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993835c3588327b6d632b0b0a8feb1