### PR TITLE
feat: add Chat with Assistant card to dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,17 @@
       <a class="button" href="/planner">Planner</a>
     </div>
   </div>
+
+  <div class="card">
+    <h2>Chat with Assistant</h2>
+    <p>Ask questions, get updates, and manage tasks through your AI assistant.</p>
+    <a class="button" href="/chat">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" style="width:24px;height:24px;vertical-align:middle;margin-right:4px">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15a2.25 2.25 0 002.25 2.25h3L9 21l3-3h5.25A2.25 2.25 0 0019.5 15V6.75A2.25 2.25 0 0017.25 4.5h-12A2.25 2.25 0 003 6.75V15z" />
+      </svg>
+      Open Chat
+    </a>
+  </div>
 </div>
 <script>
 (function(){


### PR DESCRIPTION
## Summary
- add Chat with Assistant card on dashboard linking to `/chat`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689939bfca608327bedcca8d47bd09c7