### PR TITLE
feat: add /chat page + nav button; resolve conflicts; keep font imports; brand palette via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,28 @@ curl -X POST 'https://mags-assistant.vercel.app/api/rpa?action=start' \
 
 The `/chat` interface requires the following environment variables:
 
-- `OPENAI_API_KEY` – API key for OpenAI requests.
-- `CHAT_PASSWORD` – optional password protecting the chat. If unset, the page warns that auth is disabled.
-- `NOTION_TOKEN` – token for Notion API access.
-- `NOTION_HQ_PAGE_ID` – Notion HQ page ID.
-- `NOTION_QUEUE_DB` – Notion queue database ID.
-- `STRIPE_SECRET_KEY` – Stripe API key.
-- `RESEND_API_KEY` – optional; API key for sending email notifications.
-- `NOTIFY_EMAIL` – optional email address for notifications.
-- `NOTIFY_WEBHOOK` – optional Slack/Discord webhook for notifications.
-- `BRAND_PRIMARY_HEX` – optional primary color override.
-- `BRAND_SECONDARY_HEX` – optional secondary color override.
+```
+OPENAI_API_KEY
+CHAT_PASSWORD
+NOTION_TOKEN
+NOTION_HQ_PAGE_ID
+NOTION_QUEUE_DB
+STRIPE_SECRET_KEY
+RESEND_API_KEY          # optional
+NOTIFY_EMAIL            # optional
+NOTIFY_WEBHOOK          # optional
+BRAND_PRIMARY_HEX       # optional
+BRAND_SECONDARY_HEX     # optional
+TELEGRAM_BOT_TOKEN      # optional
+TELEGRAM_CHAT_ID        # optional
+```
+
+## Notifications & Telegram
+
+Optional notifications can be sent via email or webhooks when
+`RESEND_API_KEY` is supplied along with a target `NOTIFY_EMAIL` or
+`NOTIFY_WEBHOOK`.
+For Telegram alerts, set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`.
 
 ## Scheduled Tasks (free)
 We run a free scheduler using GitHub Actions that calls `/api/cron/tick` every 15 minutes.

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -61,7 +61,7 @@ export default function ChatPage() {
           Warning: CHAT_PASSWORD is not set; chat is public.
         </div>
       )}
-      <ChatUI />
+      <ChatUI title="Mags — Chat" />
     </div>
   );
 }

--- a/app/planner/page.tsx
+++ b/app/planner/page.tsx
@@ -1,4 +1,7 @@
-import { getNotion } from '../../lib/clients/notion';
+import { getNotion } from '../../lib/notion';
+import { Inter, Fraunces } from 'next/font/google';
+const inter = Inter({ subsets: ['latin'] });
+const fraunces = Fraunces({ subsets: ['latin'] });
 
 function readProp(page: any, name: string) {
   const prop = page.properties[name];
@@ -24,31 +27,38 @@ export default async function PlannerPage() {
   const order = ['Queue', 'Running', 'Done'];
 
   return (
-    <div className="p-4 flex gap-4 overflow-x-auto">
-      {order.map((key) => (
-        <div key={key} className="min-w-[250px] flex-1">
-          <h2 className="mb-2 font-serif text-lg">{key}</h2>
-          <div className="space-y-2">
-            {cols[key]?.map((p) => {
-              const title = readProp(p, 'Task');
-              const last = readProp(p, 'Last Log') || readProp(p, 'Last Error');
-              const updated = readProp(p, 'Last Updated') || readProp(p, 'Date Updated') || '';
-              return (
-                <a
-                  key={p.id}
-                  href={p.url}
-                  target="_blank"
-                  className="block bg-white rounded shadow p-2 border"
-                >
-                  <div className="font-medium">{title}</div>
-                  {last && <div className="text-sm text-gray-600">{last}</div>}
-                  {updated && <div className="text-xs text-gray-400">{updated}</div>}
-                </a>
-              );
-            })}
+    <div className={`${inter.className} p-4`}>
+      <div className="text-right mb-4 text-sm">
+        <a href="/chat" className="underline">
+          Chat
+        </a>
+      </div>
+      <div className="flex gap-4 overflow-x-auto">
+        {order.map((key) => (
+          <div key={key} className="min-w-[250px] flex-1">
+            <h2 className={`${fraunces.className} mb-2 text-lg`}>{key}</h2>
+            <div className="space-y-2">
+              {cols[key]?.map((p) => {
+                const title = readProp(p, 'Task');
+                const last = readProp(p, 'Last Log') || readProp(p, 'Last Error');
+                const updated = readProp(p, 'Last Updated') || readProp(p, 'Date Updated') || '';
+                return (
+                  <a
+                    key={p.id}
+                    href={p.url}
+                    target="_blank"
+                    className="block bg-white rounded shadow p-2 border"
+                  >
+                    <div className="font-medium">{title}</div>
+                    {last && <div className="text-sm text-gray-600">{last}</div>}
+                    {updated && <div className="text-xs text-gray-400">{updated}</div>}
+                  </a>
+                );
+              })}
+            </div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/ChatUI.tsx
+++ b/components/ChatUI.tsx
@@ -2,8 +2,10 @@
 import { useEffect, useRef, useState } from 'react';
 
 const palette = {
-  sage: '#9BB5A3',
-  blush: '#E8C8C3',
+  // brand overrides (env takes precedence; fallback to hex)
+  sage: process.env.BRAND_PRIMARY_HEX || '#9BB5A3',
+  blush: process.env.BRAND_SECONDARY_HEX || '#E8C8C3',
+  // neutrals
   cream: '#FBF6EF',
   charcoal: '#2B2B2B',
   gold: '#D8B26E',
@@ -35,7 +37,7 @@ function renderMessage(text: string) {
   });
 }
 
-export default function ChatUI() {
+export default function ChatUI({ title }: { title?: string }) {
   const [messages, setMessages] = useState<Message[]>(() => {
     if (typeof window === 'undefined') return [];
     const saved = localStorage.getItem('mags-chat-history');
@@ -49,6 +51,10 @@ export default function ChatUI() {
     localStorage.setItem('mags-chat-history', JSON.stringify(messages));
     listRef.current?.scrollTo(0, listRef.current.scrollHeight);
   }, [messages]);
+
+  useEffect(() => {
+    if (title) document.title = title;
+  }, [title]);
 
   async function send(prompt?: string) {
     const content = prompt ?? input.trim();

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,5 +1,11 @@
 import { Client } from '@notionhq/client';
 
+export function getNotion() {
+  const token = process.env.NOTION_TOKEN;
+  if (!token) throw new Error('Missing NOTION_TOKEN');
+  return new Client({ auth: token });
+}
+
 export const notion = new Client({ auth: process.env.NOTION_TOKEN! });
 const DB = process.env.NOTION_QUEUE_DB!;
 

--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,7 @@
     <div class="button-row">
       <a class="button" href="/studio">Studio</a>
       <a class="button" href="/planner">Planner</a>
+      <a class="button" href="/chat">Chat</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add Chat page using ChatUI and protect with CHAT_PASSWORD
- expose brand palette via env vars and pass title to ChatUI
- restore font imports and Notion client helper; add Chat link on landing and planner pages; document env vars including notifications and Telegram

## Testing
- `npm i`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993725fd4c832781f587c5e14ef601