### PR TITLE
feat: add telegram approval flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ The `/chat` interface requires the following environment variables:
 - Optional: `RESEND_API_KEY`, `NOTIFY_EMAIL`
 - Telegram webhook URL: https://assistant.messyandmagnetic.com/api/telegram/webhook
 
+### Telegram approvals
+
+Proposal notifications include inline **Approve/Decline** buttons.
+Button presses send `{actionId, runId, kind}` to `/api/approve` which
+invokes the relevant worker (`sendOutreach`, schedules a follow-up, or
+marks content approved). Declines mark the run as **Rejected**.
+
 ## Scheduled Tasks (free)
 We run a free scheduler using GitHub Actions that calls `/api/cron/tick` every 15 minutes.
 

--- a/app/api/approve/route.ts
+++ b/app/api/approve/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Client } from '@notionhq/client';
+
+async function runWorker(kind: string, actionId: string) {
+  const base = process.env.API_BASE ?? '';
+  try {
+    if (kind === 'sendOutreach') {
+      await fetch(`${base}/api/outreach/run`, { method: 'POST' });
+    } else if (kind === 'followUp') {
+      await fetch(`${base}/api/outreach/seed`, { method: 'POST' });
+    } else if (kind === 'content') {
+      // handled by run status update
+    }
+  } catch {}
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { actionId, runId, kind, decision } = await req.json();
+    if (!actionId || !runId || !kind) {
+      return NextResponse.json({ ok: false, error: 'missing-fields' }, { status: 400 });
+    }
+
+    const notionToken = process.env.NOTION_TOKEN;
+    const runsDb = process.env.NOTION_DB_RUNS_ID;
+    if (!notionToken || !runsDb) {
+      return NextResponse.json({ ok: false, error: 'notion-missing' }, { status: 500 });
+    }
+    const notion = new Client({ auth: notionToken });
+    const page = await notion.pages.retrieve({ page_id: runId });
+    const status = page.properties?.Status?.status?.name ?? '';
+    if (status === 'Approved' || status === 'Rejected') {
+      return NextResponse.json({ ok: true, already: status });
+    }
+
+    if (decision === 'approve') {
+      await runWorker(kind, actionId);
+      await notion.pages.update({
+        page_id: runId,
+        properties: {
+          Status: { status: { name: kind === 'content' ? 'Content Approved' : 'Approved' } },
+        },
+      });
+    } else {
+      await notion.pages.update({
+        page_id: runId,
+        properties: { Status: { status: { name: 'Rejected' } } },
+      });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e?.message ?? 'approve-failed' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- send proposal messages with Telegram inline Approve/Decline buttons
- process approval callbacks at `/api/approve`
- forward Telegram callbacks from webhook
- document Telegram approvals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689953d4d2c883278d78cb170ad0d88e