### PR TITLE
Add donation link creation endpoint and planner button

### DIFF
--- a/lib/clients/stripe.js
+++ b/lib/clients/stripe.js
@@ -1,0 +1,9 @@
+import Stripe from 'stripe';
+
+export function getStripe() {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error('Missing STRIPE_SECRET_KEY');
+  }
+  return new Stripe(key, { apiVersion: '2023-10-16' });
+}

--- a/public/planner.html
+++ b/public/planner.html
@@ -21,6 +21,7 @@
       <div class="button-row">
         <button class="button" id="download">Download JSON</button>
         <button class="button" id="copy">Copy caption</button>
+        <button class="button" id="createLink">Create $250 link</button>
       </div>
     </div>
     <p><a class="button" href="/">← Home</a></p>

--- a/public/planner.js
+++ b/public/planner.js
@@ -39,3 +39,27 @@ $('#copy').addEventListener('click', async () => {
     console.error(err);
   }
 });
+
+$('#createLink').addEventListener('click', async () => {
+  const magsKey = localStorage.getItem('magsKey') || '';
+  const crmId = prompt('CRM Record ID (optional)') || '';
+  try {
+    const res = await fetch('/api/donations/create', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(magsKey ? { 'x-mags-key': magsKey } : {}),
+      },
+      body: JSON.stringify(crmId ? { crmId } : {}),
+    });
+    const json = await res.json().catch(() => ({}));
+    if (json.ok && json.link) {
+      try { await navigator.clipboard.writeText(json.link); } catch {}
+      alert('Link created and copied to clipboard');
+    } else {
+      alert(json.error || 'Error creating link');
+    }
+  } catch (err) {
+    alert('Error creating link');
+  }
+});


### PR DESCRIPTION
## Summary
- add `/api/donations/create` to create $250 Stripe payment links, update CRM records, and notify via email/Telegram
- add Stripe client helper
- add Planner quick button to generate and copy a $250 donation link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689954227d488327bbe9a81e6c94f6cf