### PR TITLE
feat: Stripe ↔ Notion sync (audit+fix+donations+images)

### DIFF
--- a/.github/workflows/stripe-sync.yaml
+++ b/.github/workflows/stripe-sync.yaml
@@ -1,0 +1,29 @@
+name: stripe-sync
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Stripe ↔ Notion audit
+        id: audit
+        run: |
+          OUT=$(curl -sS "$API_BASE/api/stripe/sync?mode=audit&dry=1" -H "Cookie: mags-chat=$CHAT_PASSWORD")
+          echo "$OUT"
+          echo "$OUT" > out.json
+          node -e "const o=require('./out.json');const bad=o.report && (o.report.missingInStripe.length||o.report.missingInNotion.length||o.report.mismatches.length||o.report.duplicates.length);if(bad)process.exit(1)"
+        env:
+          API_BASE: ${{ secrets.API_BASE }}
+          CHAT_PASSWORD: ${{ secrets.CHAT_PASSWORD }}
+      - name: Notify on issues
+        if: failure()
+        run: npx tsx scripts/announce.ts "Stripe sync needs attention"
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/README.md
+++ b/README.md
@@ -157,9 +157,23 @@ _(coming soon)_
 
 _(coming soon)_
 
-## Stripe audit
+## Stripe ↔ Notion sync
 
-_(coming soon)_
+Endpoint: `/api/stripe/sync`
+
+Modes:
+
+- `mode=audit&dry=1` — report differences without changes.
+- `mode=full&dry=0` — audit and apply fixes.
+
+Environment variables:
+
+- `STRIPE_SECRET_KEY`
+- `NOTION_TOKEN`
+- `PRODUCTS_DB_ID`
+- optional: `RESEND_API_KEY`, `NOTIFY_EMAIL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`
+
+Donation products can be added like any other product; create a Notion row with `Type` = `Donation` and amount/tiers as needed.
 
 ## Content planner
 

--- a/app/api/stripe/sync/route.ts
+++ b/app/api/stripe/sync/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { checkAuth } from '../../../../lib/auth';
+import { sync } from '../../../../lib/stripeSync';
+
+export async function GET(req: NextRequest) {
+  if (!checkAuth(req)) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  const url = new URL(req.url);
+  const mode = (url.searchParams.get('mode') ?? 'audit') as any;
+  const dry = url.searchParams.get('dry') !== '0';
+  const row = url.searchParams.get('row') ?? undefined;
+  try {
+    const result = await sync({ mode, dry, row });
+    return NextResponse.json(result);
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e?.message || 'sync-failed' }, { status: 500 });
+  }
+}

--- a/app/planner/page.tsx
+++ b/app/planner/page.tsx
@@ -1,4 +1,5 @@
 import { getNotion } from '../../lib/clients/notion';
+import SyncStripeButton from '../../components/SyncStripeButton';
 
 function readProp(page: any, name: string) {
   const prop = page.properties[name];
@@ -24,7 +25,11 @@ export default async function PlannerPage() {
   const order = ['Queue', 'Running', 'Done'];
 
   return (
-    <div className="p-4 flex gap-4 overflow-x-auto">
+    <div className="p-4">
+      <div className="mb-4">
+        <SyncStripeButton />
+      </div>
+      <div className="flex gap-4 overflow-x-auto">
       {order.map((key) => (
         <div key={key} className="min-w-[250px] flex-1">
           <h2 className="mb-2 font-serif text-lg">{key}</h2>
@@ -34,21 +39,22 @@ export default async function PlannerPage() {
               const last = readProp(p, 'Last Log') || readProp(p, 'Last Error');
               const updated = readProp(p, 'Last Updated') || readProp(p, 'Date Updated') || '';
               return (
-                <a
-                  key={p.id}
-                  href={p.url}
-                  target="_blank"
-                  className="block bg-white rounded shadow p-2 border"
-                >
-                  <div className="font-medium">{title}</div>
-                  {last && <div className="text-sm text-gray-600">{last}</div>}
-                  {updated && <div className="text-xs text-gray-400">{updated}</div>}
-                </a>
+                <div key={p.id} className="bg-white rounded shadow p-2 border">
+                  <a href={p.url} target="_blank" className="block">
+                    <div className="font-medium">{title}</div>
+                    {last && <div className="text-sm text-gray-600">{last}</div>}
+                    {updated && <div className="text-xs text-gray-400">{updated}</div>}
+                  </a>
+                  <div className="mt-2">
+                    <SyncStripeButton rowId={p.id} label="Fix now" />
+                  </div>
+                </div>
               );
             })}
           </div>
         </div>
       ))}
+      </div>
     </div>
   );
 }

--- a/components/ChatUI.tsx
+++ b/components/ChatUI.tsx
@@ -81,7 +81,7 @@ export default function ChatUI() {
   }
 
   const quick = [
-    { label: 'Sync Stripe ↔ Notion (two-way)', prompt: 'Sync Stripe and Notion (two-way)' },
+    { label: 'Sync Stripe ↔ Notion', prompt: 'Sync Stripe and Notion (two-way)' },
     { label: 'Generate on-brand image for selected product', prompt: 'Generate on-brand image for selected product' },
     { label: 'Audit Stripe products (propose fixes)', prompt: 'Audit Stripe products and propose fixes' },
     { label: 'Create Notion task from this chat', prompt: 'Create a Notion task from this chat' },

--- a/components/SyncStripeButton.tsx
+++ b/components/SyncStripeButton.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useState } from 'react';
+
+export default function SyncStripeButton({ rowId, label = 'Sync Stripe ↔ Notion' }: { rowId?: string; label?: string }) {
+  const [msg, setMsg] = useState('');
+  const [loading, setLoading] = useState(false);
+  async function run() {
+    setLoading(true);
+    setMsg('');
+    try {
+      const url = rowId
+        ? `/api/stripe/sync?mode=fix&row=${rowId}`
+        : '/api/stripe/sync?mode=full&dry=0';
+      const res = await fetch(url);
+      const json = await res.json();
+      setMsg(json.ok ? 'done' : json.error || 'error');
+    } catch (e: any) {
+      setMsg('error');
+    } finally {
+      setLoading(false);
+    }
+  }
+  return (
+    <div>
+      <button
+        onClick={run}
+        disabled={loading}
+        className="px-3 py-1 rounded border"
+      >
+        {loading ? 'Running…' : label}
+      </button>
+      {msg && <p className="text-xs mt-1 opacity-70">{msg}</p>}
+    </div>
+  );
+}

--- a/lib/stripeSync.ts
+++ b/lib/stripeSync.ts
@@ -1,0 +1,214 @@
+import { getStripe } from './clients/stripe';
+import { getNotion } from './clients/notion';
+import { getOpenAI } from './clients/openai';
+import { requireEnv } from './env.js';
+
+export type SyncMode = 'audit' | 'fix' | 'full';
+
+const NOTION_FIELDS: Record<string, any> = {
+  Description: { rich_text: {} },
+  Type: { select: {} },
+  'Billing Interval': { select: {} },
+  Amount: { number: { format: 'number' } },
+  Status: { status: {} },
+  'Stripe Product ID': { rich_text: {} },
+  'Stripe Price ID': { rich_text: {} },
+  'Image URL': { url: {} },
+  'Category/Tags': { multi_select: {} },
+  Notes: { rich_text: {} },
+};
+
+async function ensureSchema(notion: any, dbId: string) {
+  const db = await notion.databases.retrieve({ database_id: dbId });
+  const update: any = { properties: {} };
+  for (const [name, def] of Object.entries(NOTION_FIELDS)) {
+    if (!db.properties[name]) {
+      update.properties[name] = def;
+    }
+  }
+  if (Object.keys(update.properties).length) {
+    await notion.databases.update({ database_id: dbId, ...update });
+  }
+}
+
+function normalizeName(name: string) {
+  return name.trim().toLowerCase();
+}
+
+export async function audit() {
+  const stripe = getStripe();
+  const notion = getNotion();
+  const dbId = requireEnv('PRODUCTS_DB_ID');
+  await ensureSchema(notion, dbId);
+
+  const stripeProducts = await stripe.products.list({ limit: 100, expand: ['data.default_price'] });
+  const notionPages: any[] = [];
+  let cursor: string | undefined;
+  do {
+    const res = await notion.databases.query({ database_id: dbId, start_cursor: cursor });
+    notionPages.push(...res.results);
+    cursor = res.has_more ? res.next_cursor : undefined;
+  } while (cursor);
+
+  const notionById: Record<string, any> = {};
+  const notionByName: Record<string, any> = {};
+  for (const p of notionPages) {
+    const name = p.properties?.Name?.title?.[0]?.plain_text ?? '';
+    const pid = p.properties?.['Stripe Product ID']?.rich_text?.[0]?.plain_text ?? '';
+    if (pid) notionById[pid] = p;
+    if (name) notionByName[normalizeName(name)] = p;
+  }
+
+  const missingInNotion: any[] = [];
+  const mismatches: any[] = [];
+  for (const prod of stripeProducts.data) {
+    const match = notionById[prod.id] || notionByName[normalizeName(prod.name)];
+    if (!match) {
+      missingInNotion.push({ id: prod.id, name: prod.name });
+      continue;
+    }
+    const desc = match.properties?.Description?.rich_text?.[0]?.plain_text ?? '';
+    if (desc !== (prod.description || '')) {
+      mismatches.push({ id: prod.id, field: 'description', stripe: prod.description, notion: desc });
+    }
+  }
+
+  const missingInStripe: any[] = [];
+  for (const p of notionPages) {
+    const pid = p.properties?.['Stripe Product ID']?.rich_text?.[0]?.plain_text;
+    const name = p.properties?.Name?.title?.[0]?.plain_text ?? '';
+    if (pid) continue;
+    if (!stripeProducts.data.find((sp) => normalizeName(sp.name) === normalizeName(name))) {
+      missingInStripe.push({ id: p.id, name });
+    }
+  }
+
+  const duplicates: string[] = [];
+  const seen: Record<string, number> = {};
+  for (const p of notionPages) {
+    const pid = p.properties?.['Stripe Product ID']?.rich_text?.[0]?.plain_text;
+    if (pid) {
+      seen[pid] = (seen[pid] || 0) + 1;
+    }
+  }
+  for (const [pid, count] of Object.entries(seen)) {
+    if (count > 1) duplicates.push(pid);
+  }
+
+  return { ok: true, report: { missingInStripe, missingInNotion, mismatches, duplicates } };
+}
+
+async function createOrUpdateImage(stripe: any, product: any, notion: any, pageId: string) {
+  const notionUrl = product.properties?.['Image URL']?.url ?? '';
+  const stripeImage = product.stripe?.images?.[0];
+  if (!notionUrl && stripeImage) {
+    await notion.pages.update({ page_id: pageId, properties: { 'Image URL': { url: stripeImage } } });
+    return;
+  }
+  if (!notionUrl && !stripeImage && process.env.OPENAI_API_KEY) {
+    const openai = getOpenAI();
+    const img = await openai.images.generate({ prompt: 'pale pastels, thin cursive serif, florals, leaves, soft farmhouse aesthetic', n: 1, size: '512x512' });
+    const url = img.data[0]?.url;
+    if (url) {
+      await stripe.products.update(product.stripe.id, { images: [url] });
+      await notion.pages.update({ page_id: pageId, properties: { 'Image URL': { url } } });
+    }
+  }
+}
+
+async function createPrice(stripe: any, prodId: string, amount: number, interval?: string) {
+  if (interval) {
+    return stripe.prices.create({ product: prodId, unit_amount: amount, currency: 'usd', recurring: { interval } });
+  }
+  return stripe.prices.create({ product: prodId, unit_amount: amount, currency: 'usd' });
+}
+
+export async function fix(opts: { rowId?: string } = {}) {
+  const stripe = getStripe();
+  const notion = getNotion();
+  const dbId = requireEnv('PRODUCTS_DB_ID');
+  await ensureSchema(notion, dbId);
+  const filter = opts.rowId ? { filter: { property: 'id', value: opts.rowId } } : {};
+  const res = await notion.databases.query({ database_id: dbId });
+  const pages = res.results as any[];
+  const created: string[] = [];
+  const updated: string[] = [];
+  for (const p of pages) {
+    if (opts.rowId && p.id !== opts.rowId) continue;
+    const status = p.properties?.Status?.status?.name ?? '';
+    const name = p.properties?.Name?.title?.[0]?.plain_text ?? '';
+    const desc = p.properties?.Description?.rich_text?.[0]?.plain_text ?? '';
+    const type = p.properties?.Type?.select?.name ?? '';
+    const interval = p.properties?.['Billing Interval']?.select?.name ?? undefined;
+    const amount = p.properties?.Amount?.number ?? 0;
+    const prodId = p.properties?.['Stripe Product ID']?.rich_text?.[0]?.plain_text ?? '';
+    const priceId = p.properties?.['Stripe Price ID']?.rich_text?.[0]?.plain_text ?? '';
+
+    if (status === 'Ready to Add' && !prodId) {
+      const prod = await stripe.products.create({ name, description: desc, metadata: { type, status } });
+      const price = await createPrice(stripe, prod.id, amount, type === 'Recurring' ? interval : undefined);
+      await stripe.products.update(prod.id, { default_price: price.id });
+      await notion.pages.update({
+        page_id: p.id,
+        properties: {
+          Status: { status: { name: 'Added in Stripe' } },
+          'Stripe Product ID': { rich_text: [{ text: { content: prod.id } }] },
+          'Stripe Price ID': { rich_text: [{ text: { content: price.id } }] },
+        },
+      });
+      created.push(prod.id);
+      await createOrUpdateImage(stripe, { stripe: prod, properties: p.properties }, notion, p.id);
+    } else if (status === 'Needs Edit' && prodId) {
+      await stripe.products.update(prodId, { name, description: desc, metadata: { type, status } });
+      if (priceId) {
+        const current = await stripe.prices.retrieve(priceId);
+        if (current.unit_amount !== amount || (type === 'Recurring' && current.recurring?.interval !== interval)) {
+          const price = await createPrice(stripe, prodId, amount, type === 'Recurring' ? interval : undefined);
+          await stripe.products.update(prodId, { default_price: price.id });
+          await stripe.prices.update(priceId, { active: false });
+          await notion.pages.update({
+            page_id: p.id,
+            properties: { 'Stripe Price ID': { rich_text: [{ text: { content: price.id } }] }, Status: { status: { name: 'Added in Stripe' } } },
+          });
+        }
+      }
+      updated.push(prodId);
+      await createOrUpdateImage(stripe, { stripe: { id: prodId, images: [] }, properties: p.properties }, notion, p.id);
+    }
+  }
+  return { ok: true, created, updated };
+}
+
+export async function sync(opts: { mode: SyncMode; dry: boolean; row?: string }) {
+  const { mode, dry, row } = opts;
+  const auditRes = await audit();
+  if (dry || mode === 'audit') {
+    await logRun(mode, dry, auditRes);
+    return auditRes;
+  }
+  const fixRes = await fix({ rowId: row });
+  const result = { ...auditRes, ...fixRes };
+  await logRun(mode, dry, result);
+  return result;
+}
+
+async function logRun(mode: SyncMode, dry: boolean, result: any) {
+  const runsDb = process.env.NOTION_DB_RUNS_ID;
+  if (!runsDb) return;
+  const notion = getNotion();
+  const created = Array.isArray(result.created) ? result.created.length : 0;
+  const updated = Array.isArray(result.updated) ? result.updated.length : 0;
+  try {
+    await notion.pages.create({
+      parent: { database_id: runsDb },
+      properties: {
+        Name: { title: [{ text: { content: `Stripe sync ${mode}` } }] },
+        'Dry Run': { rich_text: [{ text: { content: dry ? 'yes' : 'no' } }] },
+        Created: { number: created },
+        Updated: { number: updated },
+      },
+    });
+  } catch {
+    // ignore logging failures
+  }
+}


### PR DESCRIPTION
## Summary
- add Stripe↔Notion sync library and API route
- planner sync button and per-row fix button
- nightly Stripe audit GitHub Action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68996e11bfd8832785212945b0b3d6b7