### PR TITLE
feat(site): scaffold Next.js + Tailwind + farmhouse theme + Stripe/assistant links

### DIFF
--- a/site/.eslintrc.json
+++ b/site/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+dist
+.env.local
+.env.production
+.env.development

--- a/site/app/about/page.tsx
+++ b/site/app/about/page.tsx
@@ -1,0 +1,10 @@
+export default function AboutPage() {
+  return (
+    <section className="py-12">
+      <h1 className="mb-4 font-heading text-3xl">About</h1>
+      <p className="text-brand-ink/80">
+        Messy & Magnetic celebrates the beauty of imperfection and the charm of slow living.
+      </p>
+    </section>
+  );
+}

--- a/site/app/api/donation/route.ts
+++ b/site/app/api/donation/route.ts
@@ -1,0 +1,26 @@
+import Stripe from 'stripe';
+import { NextResponse } from 'next/server';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2022-11-15',
+});
+
+export async function GET() {
+  try {
+    const prices = await stripe.prices.list({ lookup_keys: ['donation'], limit: 1 });
+    const price = prices.data[0];
+    if (!price) {
+      return NextResponse.json({ url: null });
+    }
+    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [{ price: price.id, quantity: 1 }],
+      success_url: `${baseUrl}/donate?success=true`,
+      cancel_url: `${baseUrl}/donate?canceled=true`,
+    });
+    return NextResponse.json({ url: session.url });
+  } catch (e) {
+    return NextResponse.json({ url: null }, { status: 500 });
+  }
+}

--- a/site/app/api/products/route.ts
+++ b/site/app/api/products/route.ts
@@ -1,0 +1,27 @@
+import Stripe from 'stripe';
+import { NextResponse } from 'next/server';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2022-11-15',
+});
+
+export async function GET() {
+  try {
+    const products = await stripe.products.list({
+      active: true,
+      expand: ['data.default_price'],
+    });
+    const data = products.data.map((p) => ({
+      id: p.id,
+      name: p.name,
+      price:
+        typeof p.default_price === 'object' && p.default_price
+          ? (p.default_price.unit_amount || 0) / 100
+          : 0,
+      image: p.images && p.images.length > 0 ? p.images[0] : null,
+    }));
+    return NextResponse.json({ products: data });
+  } catch (e) {
+    return NextResponse.json({ products: [] }, { status: 500 });
+  }
+}

--- a/site/app/contact/page.tsx
+++ b/site/app/contact/page.tsx
@@ -1,0 +1,10 @@
+export default function ContactPage() {
+  return (
+    <section className="py-12">
+      <h1 className="mb-4 font-heading text-3xl">Contact</h1>
+      <p className="text-brand-ink/80">
+        Drop us a line at <a href="mailto:hello@example.com" className="underline">hello@example.com</a>.
+      </p>
+    </section>
+  );
+}

--- a/site/app/donate/page.tsx
+++ b/site/app/donate/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function DonatePage() {
+  const [url, setUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/donation')
+      .then((res) => res.json())
+      .then((data) => setUrl(data.url))
+      .catch(() => setUrl(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <section className="py-12 text-center">
+      <h1 className="mb-4 font-heading text-3xl">Support our work</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : url ? (
+        <Link href={url} className="rounded-md bg-brand-sage px-6 py-3 text-white">
+          Donate
+        </Link>
+      ) : (
+        <p className="text-brand-ink/80">
+          Add a donation product in Stripe to enable this button.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -1,0 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --brand-sage: #9BB5A3;
+  --brand-blush: #E8C8C3;
+  --brand-cream: #FBF6EF;
+  --brand-ink: #2B2B2B;
+  --brand-gold: #D8B26E;
+}
+
+body {
+  @apply bg-brand-cream text-brand-ink font-body;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'%3E%3Cg fill='none' stroke='%239BB5A3' stroke-width='1' opacity='0.15'%3E%3Cpath d='M100 0 C120 40 120 80 100 120 C80 160 80 200 100 200'/%3E%3Cpath d='M0 100 C40 120 80 120 120 100 C160 80 200 80 200 100'/%3E%3C/g%3E%3C/svg%3E");
+  background-repeat: repeat;
+}

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from 'next';
+import { Fraunces, Inter } from 'next/font/google';
+import './globals.css';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import ChatBubble from '../components/ChatBubble';
+
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  weight: ['300', '400'],
+  variable: '--font-fraunces',
+  display: 'swap',
+});
+
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['300', '400'],
+  variable: '--font-inter',
+  display: 'swap',
+});
+
+export const metadata: Metadata = {
+  title: 'Messy & Magnetic',
+  description: 'Handcrafted goods with farmhouse charm.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={`${fraunces.variable} ${inter.variable}`}>
+      <body>
+        <Header />
+        <main className="mx-auto max-w-5xl px-4">
+          {children}
+        </main>
+        <Footer />
+        <ChatBubble />
+      </body>
+    </html>
+  );
+}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,0 +1,15 @@
+import Hero from '../components/Hero';
+import FeatureCards from '../components/FeatureCards';
+import Testimonial from '../components/Testimonial';
+import NewsletterSignup from '../components/NewsletterSignup';
+
+export default function HomePage() {
+  return (
+    <>
+      <Hero />
+      <FeatureCards />
+      <Testimonial />
+      <NewsletterSignup />
+    </>
+  );
+}

--- a/site/app/shop/page.tsx
+++ b/site/app/shop/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+
+interface Product {
+  id: string;
+  name: string;
+  price: number;
+  image?: string;
+}
+
+const placeholder = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Crect width='300' height='300' fill='%23E8C8C3'/%3E%3C/svg%3E";
+
+export default function ShopPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/products')
+      .then((res) => res.json())
+      .then((data) => setProducts(data.products || []))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <section className="py-12 text-center">
+        <p>Loading...</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="py-12">
+      <h1 className="mb-6 text-center font-heading text-3xl">Shop</h1>
+      <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+        {products.map((p) => (
+          <div
+            key={p.id}
+            className="rounded-lg bg-white/80 p-4 text-center shadow-sm"
+          >
+            <Image
+              src={p.image || placeholder}
+              alt={p.name}
+              width={300}
+              height={300}
+              className="h-48 w-full rounded object-cover"
+            />
+            <h3 className="mt-4 font-heading">{p.name}</h3>
+            <p className="text-brand-ink/80">${p.price.toFixed(2)}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/site/components/ChatBubble.tsx
+++ b/site/components/ChatBubble.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function ChatBubble() {
+  return (
+    <Link
+      href="https://assistant.messyandmagnetic.com/chat"
+      aria-label="Chat with Mags"
+      className="fixed bottom-4 right-4 rounded-full bg-brand-sage p-3 text-white shadow-lg"
+    >
+      <span className="sr-only">Chat with Mags</span>
+      💬
+    </Link>
+  );
+}

--- a/site/components/FeatureCards.tsx
+++ b/site/components/FeatureCards.tsx
@@ -1,0 +1,30 @@
+const features = [
+  {
+    title: 'Handmade Quality',
+    text: 'Every item is crafted with care and attention to detail.',
+  },
+  {
+    title: 'Natural Materials',
+    text: 'We choose materials that are gentle on you and the earth.',
+  },
+  {
+    title: 'Magnetic Charm',
+    text: 'Designs that bring a touch of magic to everyday life.',
+  },
+];
+
+export default function FeatureCards() {
+  return (
+    <section className="grid gap-6 py-12 md:grid-cols-3">
+      {features.map((f) => (
+        <div
+          key={f.title}
+          className="rounded-lg bg-white/80 p-6 text-center shadow-sm"
+        >
+          <h3 className="mb-2 font-heading text-xl">{f.title}</h3>
+          <p className="text-sm text-brand-ink/80">{f.text}</p>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/site/components/Footer.tsx
+++ b/site/components/Footer.tsx
@@ -1,0 +1,10 @@
+export default function Footer() {
+  return (
+    <footer className="mt-12 flex flex-col items-center gap-2 p-6 text-sm text-brand-ink">
+      <p>
+        Email: <a href="mailto:hello@example.com" className="underline">hello@example.com</a>
+      </p>
+      <p>Socials: coming soon</p>
+    </footer>
+  );
+}

--- a/site/components/Header.tsx
+++ b/site/components/Header.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header className="flex items-center justify-between p-4 md:p-6">
+      <Link href="/" className="font-heading text-2xl text-brand-ink">
+        Messy &amp; Magnetic
+      </Link>
+      <nav className="hidden space-x-4 md:block">
+        <Link href="/about" className="hover:text-brand-sage">About</Link>
+        <Link href="/shop" className="hover:text-brand-sage">Shop</Link>
+        <Link href="/donate" className="hover:text-brand-sage">Donate</Link>
+        <Link href="/contact" className="hover:text-brand-sage">Contact</Link>
+      </nav>
+      <Link
+        href="https://assistant.messyandmagnetic.com/chat"
+        className="ml-4 rounded-md bg-brand-sage px-3 py-2 text-sm text-white"
+      >
+        Chat with Mags
+      </Link>
+    </header>
+  );
+}

--- a/site/components/Hero.tsx
+++ b/site/components/Hero.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+export default function Hero() {
+  return (
+    <section className="flex flex-col items-center justify-center space-y-4 py-24 text-center">
+      <h1 className="text-4xl font-heading">Handcrafted for Homebodies</h1>
+      <p className="max-w-prose text-brand-ink/80">
+        Cozy goods and gifts inspired by countryside calm.
+      </p>
+      <div className="flex gap-4 pt-4">
+        <Link
+          href="/shop"
+          className="rounded-md bg-brand-sage px-6 py-3 text-white"
+        >
+          Shop
+        </Link>
+        <Link
+          href="/donate"
+          className="rounded-md bg-brand-gold px-6 py-3 text-brand-ink"
+        >
+          Donate
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/site/components/NewsletterSignup.tsx
+++ b/site/components/NewsletterSignup.tsx
@@ -1,0 +1,20 @@
+export default function NewsletterSignup() {
+  return (
+    <section className="py-12 text-center">
+      <h2 className="mb-4 font-heading text-2xl">Stay in the loop</h2>
+      <form className="mx-auto flex max-w-md gap-2">
+        <input
+          type="email"
+          placeholder="you@example.com"
+          className="flex-1 rounded-md border border-brand-sage px-3 py-2"
+        />
+        <button
+          type="submit"
+          className="rounded-md bg-brand-sage px-4 py-2 text-white"
+        >
+          Sign Up
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/site/components/Testimonial.tsx
+++ b/site/components/Testimonial.tsx
@@ -1,0 +1,10 @@
+export default function Testimonial() {
+  return (
+    <section className="py-12 text-center">
+      <blockquote className="mx-auto max-w-prose italic text-brand-ink/80">
+        "Mags' creations bring warmth and charm to my home."
+      </blockquote>
+      <p className="mt-4 font-heading">— Happy Customer</p>
+    </section>
+  );
+}

--- a/site/next-env.d.ts
+++ b/site/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mags-site",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "stripe": "14.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.0.0",
+    "@types/react": "18.2.0",
+    "autoprefixer": "10.4.14",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.3.3",
+    "typescript": "5.3.3"
+  }
+}

--- a/site/postcss.config.js
+++ b/site/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/site/tailwind.config.ts
+++ b/site/tailwind.config.ts
@@ -1,0 +1,28 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          sage: 'var(--brand-sage)',
+          blush: 'var(--brand-blush)',
+          cream: 'var(--brand-cream)',
+          ink: 'var(--brand-ink)',
+          gold: 'var(--brand-gold)',
+        },
+      },
+      fontFamily: {
+        heading: 'var(--font-fraunces)',
+        body: 'var(--font-inter)',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold `site` app with Next.js 14 app router, Tailwind farmhouse theme, and shared layout
- wire Stripe product & donation API routes and client pages for shop/donate
- add assistant links in header and chat bubble

## Testing
- `npm install` (fails: 403 Forbidden to npm registry)
- `npm test` (fails: Missing script)
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_6899761851ac8327924e98e62b07878b