### PR TITLE
feat(site): add chat link and contact notifications

### DIFF
--- a/site/app/api/contact/route.ts
+++ b/site/app/api/contact/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const { name, email, message } = await req.json();
+    const text = `New contact form submission:\nName: ${name}\nEmail: ${email}\nMessage:\n${message}`;
+
+    if (process.env.RESEND_API_KEY && process.env.NOTIFY_EMAIL) {
+      await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: 'onboarding@resend.dev',
+          to: process.env.NOTIFY_EMAIL,
+          subject: 'New contact form submission',
+          text,
+        }),
+      });
+    } else {
+      await fetch('https://assistant.messyandmagnetic.com/api/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+    }
+
+    if (process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_CHAT_ID) {
+      await fetch(
+        `https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}/sendMessage`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            chat_id: process.env.TELEGRAM_CHAT_ID,
+            text,
+          }),
+        },
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error(err);
+    return new NextResponse('Error', { status: 500 });
+  }
+}

--- a/site/app/contact/page.tsx
+++ b/site/app/contact/page.tsx
@@ -1,10 +1,13 @@
+import ContactForm from '../../components/ContactForm';
+
 export default function ContactPage() {
   return (
     <section className="py-12">
       <h1 className="mb-4 font-heading text-3xl">Contact</h1>
-      <p className="text-brand-ink/80">
-        Drop us a line at <a href="mailto:hello@example.com" className="underline">hello@example.com</a>.
+      <p className="mb-4 text-brand-ink/80">
+        Have a question or just want to say hi? Send us a message below.
       </p>
+      <ContactForm />
     </section>
   );
 }

--- a/site/components/ContactForm.tsx
+++ b/site/components/ContactForm.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function ContactForm() {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus('loading');
+    const formData = new FormData(e.currentTarget);
+    const res = await fetch('/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: formData.get('name'),
+        email: formData.get('email'),
+        message: formData.get('message'),
+      }),
+    });
+    if (res.ok) {
+      setStatus('success');
+      e.currentTarget.reset();
+    } else {
+      setStatus('error');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto max-w-md space-y-4">
+      <input
+        name="name"
+        type="text"
+        required
+        placeholder="Your name"
+        className="w-full rounded-md border border-brand-sage px-3 py-2"
+      />
+      <input
+        name="email"
+        type="email"
+        required
+        placeholder="you@example.com"
+        className="w-full rounded-md border border-brand-sage px-3 py-2"
+      />
+      <textarea
+        name="message"
+        required
+        placeholder="Your message"
+        className="w-full rounded-md border border-brand-sage px-3 py-2"
+        rows={4}
+      />
+      <button
+        type="submit"
+        disabled={status === 'loading'}
+        className="rounded-md bg-brand-sage px-4 py-2 text-white"
+      >
+        {status === 'loading' ? 'Sending...' : 'Send'}
+      </button>
+      {status === 'success' && (
+        <p className="text-green-600">Thanks! We&apos;ll be in touch.</p>
+      )}
+      {status === 'error' && (
+        <p className="text-red-600">Something went wrong. Please try again.</p>
+      )}
+    </form>
+  );
+}

--- a/site/components/Header.tsx
+++ b/site/components/Header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
         href="https://assistant.messyandmagnetic.com/chat"
         className="ml-4 rounded-md bg-brand-sage px-3 py-2 text-sm text-white"
       >
-        Chat with Mags
+        Chat
       </Link>
     </header>
   );

--- a/site/components/Testimonial.tsx
+++ b/site/components/Testimonial.tsx
@@ -2,7 +2,7 @@ export default function Testimonial() {
   return (
     <section className="py-12 text-center">
       <blockquote className="mx-auto max-w-prose italic text-brand-ink/80">
-        "Mags' creations bring warmth and charm to my home."
+        &ldquo;Mags&rsquo; creations bring warmth and charm to my home.&rdquo;
       </blockquote>
       <p className="mt-4 font-heading">— Happy Customer</p>
     </section>


### PR DESCRIPTION
## Summary
- expose Chat link to the assistant from the marketing header
- add contact form that emails via Resend or posts to assistant
- send Telegram alert on successful contact submission

## Testing
- `npm test`
- `cd site && npm test` (fails: Missing script)
- `cd site && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689981dbba1483278699ff686abddb73