### PR TITLE
feat: scaffold social draft generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,3 +213,18 @@ curl -X POST "$API_BASE/api/notion/backfill-defaults" \
 ## Content planner
 
 _(coming soon)_
+
+## Social drafts & trending sounds
+
+Early support for generating short-form video drafts from a Google Drive inbox and scheduling with trending audio.
+
+### Required environment variables
+
+- `DRIVE_INBOX_FOLDER_ID` – Google Drive folder containing new media.
+- `NOTION_CONTENT_DB_ID` – Notion database for the content queue.
+- `OPENAI_API_KEY` – used for transcriptions and caption suggestions.
+- `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` – send approval previews.
+- `BROWSERLESS_KEY` – headless browser for TikTok/Instagram scheduling.
+- `YT_CLIENT_ID` / `YT_CLIENT_SECRET` / `YT_REFRESH_TOKEN` – YouTube uploads.
+- `TIKTOK_SESSION_COOKIE` – TikTok session with access to trending sounds.
+- `IG_SESSION_COOKIE` – Instagram session for selecting trending audio.

--- a/apps/api/lib/tasks/index.ts
+++ b/apps/api/lib/tasks/index.ts
@@ -9,6 +9,7 @@ import { socialCollectInbox } from "./social-inbox";
 import { socialRefreshAnalytics } from "./social-analytics";
 import { stripeAudit } from "./stripe-audit";
 import { outreachRun } from "./outreach";
+import { socialGenerateDrafts } from "./social-drafts";
 
 export type TaskResult = { name: string; ok: boolean; msg?: string };
 export type TaskFn = () => Promise<TaskResult>;
@@ -22,6 +23,7 @@ export const tasks: Record<string, TaskFn> = {
   "social.post_due": socialPostDue,
   "social.collect_inbox": socialCollectInbox,
   "social.refresh_analytics": socialRefreshAnalytics,
+  "social.generate_drafts": socialGenerateDrafts,
   "stripe.audit": stripeAudit,
   "outreach.run": outreachRun,
 };
@@ -35,6 +37,7 @@ const taskFlags: Record<string, string> = {
   "social.post_due": "TASK_SOCIAL_POST_DUE",
   "social.collect_inbox": "TASK_SOCIAL_INBOX",
   "social.refresh_analytics": "TASK_SOCIAL_ANALYTICS",
+  "social.generate_drafts": "TASK_SOCIAL_GENERATE_DRAFTS",
   "stripe.audit": "TASK_STRIPE_AUDIT",
   "outreach.run": "TASK_OUTREACH_RUN",
 };

--- a/apps/api/lib/tasks/social-drafts.ts
+++ b/apps/api/lib/tasks/social-drafts.ts
@@ -1,0 +1,11 @@
+import { generateDraftsFromDrive } from "../social";
+import type { TaskResult } from "./index";
+
+export async function socialGenerateDrafts(): Promise<TaskResult> {
+  try {
+    const r = await generateDraftsFromDrive();
+    return { name: "social.generate_drafts", ok: r.ok !== false, msg: r.items ? `${r.items}_items` : r.msg };
+  } catch (err: any) {
+    return { name: "social.generate_drafts", ok: false, msg: err?.message || String(err) };
+  }
+}

--- a/apps/api/src/routes/social/generate-drafts.ts
+++ b/apps/api/src/routes/social/generate-drafts.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from "next/server";
+import { generateDraftsFromDrive } from "../../../lib/social";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const result = await generateDraftsFromDrive();
+  const status = result.ok === false ? 501 : 200;
+  return NextResponse.json(result, { status });
+}


### PR DESCRIPTION
## Summary
- scan Google Drive inbox for new media and return counts
- expose `social.generate_drafts` task and API route
- document env vars for social drafts and trending audio

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ac4d4ed048327b62eef9829b565d7