### PR TITLE
feat: add automation agents

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,18 @@
+name: link-check
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check links
+        run: npx tsx scripts/link_check.ts

--- a/.github/workflows/memory-clean.yml
+++ b/.github/workflows/memory-clean.yml
@@ -1,0 +1,19 @@
+name: memory-clean
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      NOTION_DB_MEMORY: ${{ secrets.NOTION_DB_MEMORY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compact memory DB
+        run: npx tsx scripts/memory/compact.ts

--- a/.github/workflows/nightly-trends.yml
+++ b/.github/workflows/nightly-trends.yml
@@ -1,0 +1,24 @@
+name: nightly-trends
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      NOTION_DB_TRENDS: ${{ secrets.NOTION_DB_TRENDS }}
+      WORKER_URL: ${{ secrets.WORKER_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch trends
+        run: npx tsx scripts/trends.ts
+      - name: Notify failure
+        if: failure()
+        run: |
+          curl -sS -X POST "$WORKER_URL/api/notify" \
+            -H "content-type: application/json" \
+            -d '{"summary":"nightly trends failed"}'

--- a/apps-script/DriveWatcher/Code.gs
+++ b/apps-script/DriveWatcher/Code.gs
@@ -1,0 +1,32 @@
+const WORKER_URL = 'https://tight-snow-2840.messyandmagnetic.workers.dev/api/media/new';
+const FETCH_PASS = PropertiesService.getScriptProperties().getProperty('FETCH_PASS');
+const RAW_FOLDER_ID = PropertiesService.getScriptProperties().getProperty('RAW_FOLDER_ID');
+const INBOX_NAME = 'Inbox';
+
+function onChange(e) {
+  const folder = DriveApp.getFolderById(RAW_FOLDER_ID);
+  const files = folder.getFiles();
+  while (files.hasNext()) {
+    const file = files.next();
+    const ts = Utilities.formatDate(new Date(), 'UTC', 'yyyyMMdd-HHmm');
+    const ext = file.getName().split('.').pop();
+    const newName = `${ts}_${file.getName()}`;
+    file.setName(newName);
+    const inbox = folder.getParents().next().getFoldersByName(INBOX_NAME).next();
+    inbox.addFile(file);
+    folder.removeFile(file);
+    const payload = {
+      fileId: file.getId(),
+      name: file.getName(),
+      size: file.getSize(),
+      mimeType: file.getMimeType(),
+    };
+    UrlFetchApp.fetch(WORKER_URL, {
+      method: 'post',
+      contentType: 'application/json',
+      payload: JSON.stringify(payload),
+      headers: { 'X-Fetch-Pass': FETCH_PASS },
+      muteHttpExceptions: true,
+    });
+  }
+}

--- a/apps-script/DriveWatcher/README.md
+++ b/apps-script/DriveWatcher/README.md
@@ -1,0 +1,10 @@
+# Drive Watcher
+
+1. Open [script.google.com](https://script.google.com) and create a new project.
+2. Paste `Code.gs` into the editor.
+3. In **Project Settings**, add script properties `FETCH_PASS` and `RAW_FOLDER_ID`.
+4. From the left menu choose **Triggers** and add a trigger:
+   - Function: `onChange`
+   - Event source: Time-driven
+   - Type: Every 10 minutes
+5. Save. New files in the Raw Uploads folder will be renamed, moved to `Inbox`, and posted to the Worker endpoint.

--- a/docs/notion-webhook.md
+++ b/docs/notion-webhook.md
@@ -1,0 +1,30 @@
+# Notion Scheduler Webhook
+
+Database fields (minimal):
+
+```json
+{
+  "Title": { "title": {} },
+  "Status": { "select": {"options": ["Idea","Editing","Ready","Queued","Posted"]}},
+  "Platform": { "multi_select": {} },
+  "Asset IDs": { "multi_select": {} },
+  "BestTime": { "rich_text": {} },
+  "Notes": { "rich_text": {} }
+}
+```
+
+Create an automation in Notion:
+
+1. In the Scheduler database, click **Automations → Add Automation**.
+2. Trigger: When **Status** changes to **Ready**.
+3. Action: **Send a webhook** and paste your Worker URL `/api/notion/changed`.
+4. Save.
+
+## Telegram Bot Commands
+
+Register the following commands with BotFather:
+
+- `/status` – check worker health
+- `/queue` – list next queued posts
+- `/reschedule` – `/reschedule {id} {HH:mm}` update BestTime
+- `/promote` – `/promote {id}` mark a post as Posted

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "build": "echo \"static + api\"",
     "start": "node server.js || echo \"Using Vercel serverless\"",
-    "test": "node --check api/router.js"
+    "test": "node --check api/router.js",
+    "trends": "tsx scripts/trends.ts",
+    "link-check": "tsx scripts/link_check.ts",
+    "memory:compact": "tsx scripts/memory/compact.ts"
   },
   "dependencies": {
     "@notionhq/client": "^2.2.15",

--- a/public/check.html
+++ b/public/check.html
@@ -14,14 +14,18 @@
   <div><button id="tally">Test Tally OK</button> <span id="tallyRes"></span></div>
   <div><button id="stripe">Test Stripe OK</button> <span id="stripeRes"></span></div>
   <div><button id="notion">Show Notion status</button> <span id="notionRes"></span></div>
+  <div><button id="publish">Cron Publish Queue (dry-run)</button> <span id="publishRes"></span></div>
+  <div><button id="queueHead">List Queue Head</button> <span id="queueHeadRes"></span></div>
   <p><a href="https://mags-assistant.vercel.app">Vercel Prod</a></p>
 </div>
 <script>
-async function call(id, method, url, body, headers){const res=document.getElementById(id+'Res');res.textContent='…';try{const r=await fetch(url,{method,headers:{'content-type':'application/json',...(headers||{})},body:body?JSON.stringify(body):undefined});const j=await r.json();res.textContent=j.ok?'ok':'fail'}catch(e){res.textContent='error'}}
+async function call(id, method, url, body, headers){const res=document.getElementById(id+'Res');res.textContent='…';try{const baseHeaders={'content-type':'application/json',...(headers||{})};if(method==='POST'){baseHeaders['X-Fetch-Pass']=localStorage.getItem('fetch-pass')||'';}const r=await fetch(url,{method,headers:baseHeaders,body:body?JSON.stringify(body):undefined});const j=await r.json();res.textContent=j.ok?'ok':'fail'}catch(e){res.textContent='error'}}
 document.getElementById('ping').onclick=()=>call('ping','POST','/api/telegram/send',{text:'ping'});
 document.getElementById('tally').onclick=()=>call('tally','POST','/api/tally/webhook',{check:true});
 document.getElementById('stripe').onclick=()=>call('stripe','POST','/api/stripe/webhook',{});
 document.getElementById('notion').onclick=()=>call('notion','GET','/diag');
+document.getElementById('publish').onclick=()=>call('publish','POST','/api/cron/publish-queue?dry=1',{});
+document.getElementById('queueHead').onclick=()=>call('queueHead','GET','/api/queue/head');
 </script>
 </body>
 </html>

--- a/scripts/link_check.ts
+++ b/scripts/link_check.ts
@@ -1,0 +1,60 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const repo = process.env.GITHUB_REPOSITORY || '';
+const token = process.env.GITHUB_TOKEN || '';
+
+function collectLinks(): string[] {
+  const links = new Set<string>();
+  // public/check.html
+  const check = readFileSync('public/check.html', 'utf8');
+  for (const m of check.matchAll(/href="(https?:[^"#]+)"/g)) links.add(m[1]);
+  // markdown files
+  function walk(dir:string){
+    for (const f of readdirSync(dir,{withFileTypes:true})){
+      if (f.name.startsWith('.')) continue;
+      const p = join(dir,f.name);
+      if (f.isDirectory()) walk(p);
+      else if (f.name.endsWith('.md')){
+        const text = readFileSync(p,'utf8');
+        for (const m of text.matchAll(/https?:[^\)\s]+/g)) links.add(m[0]);
+      }
+    }
+  }
+  walk('.');
+  return Array.from(links);
+}
+
+async function check(url:string){
+  try{
+    const r = await fetch(url,{method:'HEAD'});
+    if(!r.ok) return `${url} -> ${r.status}`;
+  }catch(e){
+    return `${url} -> error`;
+  }
+  return '';
+}
+
+async function run(){
+  const links = collectLinks();
+  const broken:string[] = [];
+  for(const l of links){
+    const res = await check(l);
+    if(res) broken.push(res);
+  }
+  if(broken.length===0){
+    console.log('no broken links');
+    return;
+  }
+  const body = `Broken links:\n\n${broken.join('\n')}`;
+  const issues = await fetch(`https://api.github.com/repos/${repo}/issues?state=open`,{headers:{Authorization:`Bearer ${token}`}}).then(r=>r.json());
+  let issue = issues.find((i:any)=>i.title==='Link Breakage');
+  if(!issue){
+    issue = await fetch(`https://api.github.com/repos/${repo}/issues`,{method:'POST',headers:{Authorization:`Bearer ${token}`,'content-type':'application/json'},body:JSON.stringify({title:'Link Breakage',body})}).then(r=>r.json());
+  }else{
+    await fetch(`https://api.github.com/repos/${repo}/issues/${issue.number}/comments`,{method:'POST',headers:{Authorization:`Bearer ${token}`,'content-type':'application/json'},body:JSON.stringify({body})});
+  }
+  console.log('reported', broken.length, 'links');
+}
+
+run().catch(err=>{console.error(err);process.exit(1);});

--- a/scripts/memory/compact.ts
+++ b/scripts/memory/compact.ts
@@ -1,0 +1,38 @@
+import { Client } from '@notionhq/client';
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+const db = process.env.NOTION_DB_MEMORY || '';
+const repo = process.env.GITHUB_REPOSITORY || '';
+const token = process.env.GITHUB_TOKEN || '';
+
+async function archiveDone(){
+  const { results } = await notion.databases.query({
+    database_id: db,
+    filter: { property: 'Status', select: { equals: 'Done' } }
+  });
+  for(const page of results){
+    await notion.pages.update({page_id:page.id, archived:true});
+  }
+  return results.length;
+}
+
+async function run(){
+  if(!process.env.NOTION_TOKEN || !db){
+    console.error('Missing Notion env');
+    return;
+  }
+  const archived = await archiveDone();
+  const summary = `Archived ${archived} done items.`;
+  console.log(summary);
+  if(!token||!repo) return;
+  const body = summary;
+  const issues = await fetch(`https://api.github.com/repos/${repo}/issues?state=open`,{headers:{Authorization:`Bearer ${token}`}}).then(r=>r.json());
+  let issue = issues.find((i:any)=>i.title==='Memory Report');
+  if(!issue){
+    await fetch(`https://api.github.com/repos/${repo}/issues`,{method:'POST',headers:{Authorization:`Bearer ${token}`,'content-type':'application/json'},body:JSON.stringify({title:'Memory Report',body})});
+  }else{
+    await fetch(`https://api.github.com/repos/${repo}/issues/${issue.number}/comments`,{method:'POST',headers:{Authorization:`Bearer ${token}`,'content-type':'application/json'},body:JSON.stringify({body})});
+  }
+}
+
+run().catch(err=>{console.error(err);process.exit(1);});

--- a/scripts/trends.ts
+++ b/scripts/trends.ts
@@ -1,0 +1,49 @@
+import { Client } from '@notionhq/client';
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+const db = process.env.NOTION_DB_TRENDS || '';
+
+async function fetchHN() {
+  const r = await fetch('https://hn.algolia.com/api/v1/search?tags=front_page');
+  const j = await r.json();
+  return j.hits.slice(0,3).map((h:any)=>({title:h.title, url:h.url || h.story_url}));
+}
+
+async function fetchGitHub() {
+  const r = await fetch('https://gh-trending-api.de.a9sapp.eu/repositories');
+  const j = await r.json();
+  return j.slice(0,3).map((repo:any)=>({title:repo.repositoryName, url:repo.url}));
+}
+
+async function fetchNYT() {
+  const r = await fetch('https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml');
+  const text = await r.text();
+  const matches = [...text.matchAll(/<item>\s*<title><!\[CDATA\[(.*?)\]\]><\/title>\s*<link>(.*?)<\/link>/g)];
+  return matches.slice(0,3).map(m=>({title:m[1], url:m[2]}));
+}
+
+async function save(items:any[], source:string) {
+  for (const it of items) {
+    await notion.pages.create({
+      parent:{database_id:db},
+      properties:{
+        Name:{title:[{text:{content:it.title}}]},
+        Source:{select:{name:source}},
+        Link:{url:it.url}
+      }
+    });
+  }
+}
+
+async function main() {
+  if (!process.env.NOTION_TOKEN || !db) {
+    console.error('Missing Notion env');
+    return;
+  }
+  await save(await fetchHN(),'HN');
+  await save(await fetchGitHub(),'GitHub');
+  await save(await fetchNYT(),'NYT');
+  console.log('Trends saved');
+}
+
+main().catch(err=>{console.error(err);process.exit(1);});

--- a/workers/worker.js
+++ b/workers/worker.js
@@ -1,0 +1,161 @@
+import { Client } from '@notionhq/client';
+
+const json = (obj, status=200) => new Response(JSON.stringify(obj), {status, headers:{'content-type':'application/json'}});
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const { pathname, searchParams } = url;
+    const method = request.method;
+    const requirePass = () => {
+      if (request.headers.get('x-fetch-pass') !== env.FETCH_PASS) {
+        return json({ ok: false, error: 'unauthorized' }, 401);
+      }
+    };
+
+    if (pathname === '/api/health' && method === 'GET') {
+      return json({ ok: true });
+    }
+
+    if (pathname === '/api/cron/heartbeat' && method === 'GET') {
+      await env.STATUS_KV?.put('last_heartbeat', Date.now().toString());
+      return json({ ok: true });
+    }
+
+    if (pathname === '/api/cron/publish-queue' && method === 'POST') {
+      const unauthorized = requirePass();
+      if (unauthorized) return unauthorized;
+      const dry = searchParams.get('dry');
+      const items = await fetchReady(env);
+      if (!dry) await queueItems(items, env);
+      return json({ ok: true, count: items.length, dry: Boolean(dry) });
+    }
+
+    if (pathname === '/api/queue/head' && method === 'GET') {
+      const items = await getQueued(env);
+      return json({ ok: true, items: items.slice(0,5) });
+    }
+
+    if (pathname === '/api/media/new' && method === 'POST') {
+      const unauthorized = requirePass();
+      if (unauthorized) return unauthorized;
+      const body = await request.json();
+      ctx.waitUntil(env.POST_QUEUE.send(body));
+      return json({ ok: true });
+    }
+
+    if (pathname === '/api/notion/changed' && method === 'POST') {
+      const body = await request.json();
+      await env.STATUS_KV?.put(`notion:${body.id}`, JSON.stringify(body));
+      ctx.waitUntil(env.POST_QUEUE?.send({ event: 'notion', body }));
+      return json({ ok: true });
+    }
+
+    if (pathname === '/api/telegram/webhook' && method === 'POST') {
+      const update = await request.json();
+      const message = update?.message?.text || '';
+      const chatId = update?.message?.chat?.id || env.TELEGRAM_CHAT_ID;
+      const reply = async (text) => {
+        if (!env.TELEGRAM_BOT_TOKEN || !chatId) return;
+        await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ chat_id: chatId, text })
+        });
+      };
+      if (message.startsWith('/status')) {
+        const r = await fetch(new URL('/api/health', url.origin).toString());
+        const j = await r.json();
+        await reply(j.ok ? 'OK' : 'FAIL');
+      } else if (message.startsWith('/queue')) {
+        const items = await getQueued(env);
+        const text = items.slice(0,5).map(i=>`- ${i.title} at ${i.time}`).join('\n') || 'empty';
+        await reply(text);
+      } else if (message.startsWith('/reschedule')) {
+        const parts = message.split(/\s+/);
+        if (parts.length >=3) {
+          await updateTime(env, parts[1], parts[2]);
+          await reply('rescheduled');
+        }
+      } else if (message.startsWith('/promote')) {
+        const parts = message.split(/\s+/);
+        if (parts.length >=2) {
+          await promote(env, parts[1]);
+          await reply('promoted');
+        }
+      }
+      return json({ ok: true });
+    }
+
+    return new Response('Not found', { status: 404 });
+  },
+
+  async queue(batch, env) {
+    for (const msg of batch.messages) {
+      try {
+        // placeholder for processing media
+        await env.STATUS_KV?.put('last_media', Date.now().toString());
+        msg.ack();
+      } catch (e) {
+        msg.retry();
+      }
+    }
+  },
+
+  async scheduled(event, env, ctx) {
+    ctx.waitUntil(processPublishQueue(env));
+  }
+};
+
+async function processPublishQueue(env) {
+  const items = await fetchReady(env);
+  await queueItems(items, env);
+}
+
+async function fetchReady(env) {
+  if (!env.NOTION_TOKEN || !env.NOTION_DB_SCHEDULER) return [];
+  const notion = new Client({ auth: env.NOTION_TOKEN });
+  const res = await notion.databases.query({
+    database_id: env.NOTION_DB_SCHEDULER,
+    filter: { property: 'Status', select: { equals: 'Ready' } }
+  });
+  return res.results.map((p:any)=>({ id:p.id, title:p.properties.Title?.title?.[0]?.plain_text || 'untitled', time:p.properties.BestTime?.rich_text?.[0]?.plain_text || '' }));
+}
+
+async function queueItems(items:any[], env:any) {
+  if (!env.NOTION_TOKEN) return;
+  const notion = new Client({ auth: env.NOTION_TOKEN });
+  for (const it of items) {
+    await notion.pages.update({ page_id: it.id, properties: { Status: { select: { name: 'Queued' } } } });
+    if (env.TELEGRAM_BOT_TOKEN && env.TELEGRAM_CHAT_ID) {
+      await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ chat_id: env.TELEGRAM_CHAT_ID, text: `Queued: ${it.title}` })
+      });
+    }
+  }
+}
+
+async function getQueued(env:any) {
+  if (!env.NOTION_TOKEN || !env.NOTION_DB_SCHEDULER) return [];
+  const notion = new Client({ auth: env.NOTION_TOKEN });
+  const res = await notion.databases.query({
+    database_id: env.NOTION_DB_SCHEDULER,
+    filter: { property: 'Status', select: { equals: 'Queued' } },
+    sorts: [{ property: 'BestTime', direction: 'ascending' }]
+  });
+  return res.results.map((p:any)=>({ id:p.id, title:p.properties.Title?.title?.[0]?.plain_text || 'untitled', time:p.properties.BestTime?.rich_text?.[0]?.plain_text || '' }));
+}
+
+async function updateTime(env:any, id:string, time:string) {
+  if (!env.NOTION_TOKEN) return;
+  const notion = new Client({ auth: env.NOTION_TOKEN });
+  await notion.pages.update({ page_id: id, properties: { BestTime: { rich_text: [{ text: { content: time } }] } } });
+}
+
+async function promote(env:any, id:string) {
+  if (!env.NOTION_TOKEN) return;
+  const notion = new Client({ auth: env.NOTION_TOKEN });
+  await notion.pages.update({ page_id: id, properties: { Status: { select: { name: 'Posted' } } } });
+}


### PR DESCRIPTION
## Summary
- schedule nightly trends, link checks, and memory cleanup GitHub workflows
- expand Cloudflare worker with cron routes, queue handling, Notion webhooks, and Telegram commands
- add check page controls, Drive watcher script, and helper scripts for trends and link checks

## Testing
- `npm test`

### URLs to verify
- https://mags-assistant.vercel.app/check.html
- https://tight-snow-2840.messyandmagnetic.workers.dev/api/health

### Example commands
```bash
curl -X POST https://tight-snow-2840.messyandmagnetic.workers.dev/api/media/new \
  -H "Content-Type: application/json" \
  -H "X-Fetch-Pass: $FETCH_PASS" \
  -d '{"fileId":"123","name":"demo.mp4","folder":"Raw Uploads"}'

curl -X POST "https://tight-snow-2840.messyandmagnetic.workers.dev/api/cron/publish-queue?dry=1" \
  -H "X-Fetch-Pass: $FETCH_PASS"
```

### Manual setup
- Create Notion automation for Scheduler DB pointing to `/api/notion/changed`
- Bind Cloudflare Queue `POST_QUEUE` and KV `STATUS_KV` to the worker


------
https://chatgpt.com/codex/tasks/task_e_689ba46fde0083279e74e0e8befab63c