### PR TITLE
feat: add agent worker and ops tooling

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,26 @@
+# Operations
+
+## One-time setup
+1. Deploy the Cloudflare Worker and note its public URL.
+2. Set the Telegram webhook to `https://tight-snow-2840.messyandmagnetic.workers.dev/api/telegram`.
+3. Configure all required secrets on both Vercel and Cloudflare (`TELEGRAM_*`, `NOTION_*`, `STRIPE_*`, `TALLY_WEBHOOK_SECRET`, `RESEND_API_KEY`, `GOOGLE_*`, optional `FETCH_PASS`).
+4. Configure the Vercel project to serve `/public/check.html` and expose `/api/*` routes.
+5. Enable the Worker cron for daily execution.
+6. Confirm `/public/check.html` points at the correct Worker base URL.
+
+## Daily checklist
+- Open `/check.html`.
+- Ensure all probes show green.
+- Press **Sync** and **Audit** if needed and confirm success messages.
+
+## Telegram commands
+- `/ping` – verify the bot is online.
+- `/help` – list commands.
+- `/sync` – run the Stripe → Notion sync.
+- `/audit` – run the price audit.
+
+## Adding a new agent
+1. Implement the agent function and export it from `src/agent/dispatcher.ts`.
+2. Map the agent name to the function in the dispatcher.
+3. Create a Worker route (e.g. `/agent/your-agent`) that calls `runAgent`.
+4. Optionally add buttons or probes in `/public/check.html`.

--- a/public/check.html
+++ b/public/check.html
@@ -21,9 +21,11 @@
   // --- CONFIG ---
   const WORKER_BASE = 'https://tight-snow-2840.messyandmagnetic.workers.dev';
   const ENDPOINTS = [
+    { name: 'Vercel /api/health', url: '/api/health' },
+    { name: 'Vercel /api/stripe', url: '/api/stripe', method: 'POST' },
     { name: 'Worker /health', url: `${WORKER_BASE}/health` },
-    { name: 'Worker /api/stripe/sync',  url: `${WORKER_BASE}/api/stripe/sync` },
-    { name: 'Worker /api/stripe/audit', url: `${WORKER_BASE}/api/stripe/audit` },
+    { name: 'Worker /agent/sync/stripe-to-notion', url: `${WORKER_BASE}/agent/sync/stripe-to-notion`, method: 'POST' },
+    { name: 'Worker /agent/audit/prices', url: `${WORKER_BASE}/agent/audit/prices`, method: 'POST' },
   ];
 
   // Optional: set this in DevTools for gated calls
@@ -48,8 +50,10 @@
       li.textContent = `${ep.name}: probing…`;
       ul.appendChild(li);
       try {
-        const r = await fetch(ep.url, { method: 'GET' });
-        li.textContent = `${ep.name}: ${r.ok ? 'ok' : `HTTP ${r.status}`}`;
+        const r = await fetch(ep.url, { method: ep.method || 'GET', headers: ep.method === 'POST' ? {'Content-Type':'application/json'} : undefined, body: ep.method === 'POST' ? '{}' : undefined });
+        let msg = 'ok';
+        try { const j = await r.json(); msg = j.msg || j.type || (j.ok ? 'ok' : 'fail'); } catch {}
+        li.textContent = `${ep.name}: ${r.ok ? msg : `HTTP ${r.status}`}`;
         li.style.color = r.ok ? 'green' : 'crimson';
       } catch (e) {
         li.textContent = `${ep.name}: network error`;
@@ -72,8 +76,8 @@
     const el = document.getElementById('sync-status');
     color(el, true, 'syncing…');
     try {
-      const { ok, data } = await postJSON(`${WORKER_BASE}/api/stripe/sync`);
-      color(el, ok, ok ? 'synced' : `sync failed`);
+      const { ok, data } = await postJSON(`${WORKER_BASE}/agent/sync/stripe-to-notion`);
+      color(el, ok, ok ? (data.msg || 'synced') : `sync failed`);
       if (!ok) console.warn('sync error', data);
     } catch (e) {
       color(el, false, 'sync network error');
@@ -84,8 +88,8 @@
     const el = document.getElementById('audit-status');
     color(el, true, 'auditing…');
     try {
-      const { ok, data } = await postJSON(`${WORKER_BASE}/api/stripe/audit`);
-      color(el, ok, ok ? 'audited' : `audit failed`);
+      const { ok, data } = await postJSON(`${WORKER_BASE}/agent/audit/prices`);
+      color(el, ok, ok ? (data.msg || 'audited') : `audit failed`);
       if (!ok) console.warn('audit error', data);
     } catch (e) {
       color(el, false, 'audit network error');

--- a/scripts/dev-check.mjs
+++ b/scripts/dev-check.mjs
@@ -1,0 +1,18 @@
+const WORKER = process.env.WORKER_URL || 'https://tight-snow-2840.messyandmagnetic.workers.dev';
+const VERCEL = process.env.VERCEL_URL || 'https://mags-assistant.vercel.app';
+const FETCH_PASS = process.env.FETCH_PASS;
+
+async function test(name, url, opts = {}) {
+  try {
+    const res = await fetch(url, opts);
+    console.log(`${res.ok ? 'PASS' : 'FAIL'} ${name} ${res.status}`);
+  } catch (e) {
+    console.log(`FAIL ${name} ${e.message}`);
+  }
+}
+
+await test('Vercel /api/health', `${VERCEL}/api/health`);
+await test('Vercel /api/stripe', `${VERCEL}/api/stripe`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+await test('Worker /health', `${WORKER}/health`);
+await test('Worker /agent/sync/stripe-to-notion', `${WORKER}/agent/sync/stripe-to-notion`, { method: 'POST', headers: { 'Content-Type': 'application/json', ...(FETCH_PASS ? { 'X-Fetch-Pass': FETCH_PASS } : {}) }, body: '{}' });
+await test('Worker /agent/audit/prices', `${WORKER}/agent/audit/prices`, { method: 'POST', headers: { 'Content-Type': 'application/json', ...(FETCH_PASS ? { 'X-Fetch-Pass': FETCH_PASS } : {}) }, body: '{}' });

--- a/src/agent/dispatcher.ts
+++ b/src/agent/dispatcher.ts
@@ -1,0 +1,134 @@
+export type AgentPayload = any;
+export type AgentEnv = any;
+export type AgentResponse = Record<string, any>;
+export type AgentFn = (payload: AgentPayload, env: AgentEnv) => Promise<AgentResponse>;
+
+const agents: Record<string, AgentFn> = {
+  'sync/stripe-to-notion': async (_payload, env) => {
+    // fetch Stripe products and prices
+    if (!env.STRIPE_SECRET_KEY || !env.NOTION_TOKEN || !env.NOTION_DATABASE_ID) {
+      return { ok: false, error: 'missing env' };
+    }
+    const stripeHeaders = {
+      Authorization: `Bearer ${env.STRIPE_SECRET_KEY}`,
+    };
+    const [prodRes, priceRes] = await Promise.all([
+      fetch('https://api.stripe.com/v1/products?limit=100', { headers: stripeHeaders }),
+      fetch('https://api.stripe.com/v1/prices?limit=100', { headers: stripeHeaders }),
+    ]);
+    const products = (await prodRes.json()).data || [];
+    const prices = (await priceRes.json()).data || [];
+    const prodMap: Record<string, any> = {};
+    for (const p of products) prodMap[p.id] = p;
+
+    const notionHeaders = {
+      Authorization: `Bearer ${env.NOTION_TOKEN}`,
+      'Notion-Version': '2022-06-28',
+      'Content-Type': 'application/json',
+    };
+    const dbId = env.NOTION_DATABASE_ID;
+    let updated = 0;
+    for (const price of prices) {
+      const product = prodMap[price.product];
+      const name = price.nickname || product?.name || price.id;
+      const query = await fetch(`https://api.notion.com/v1/databases/${dbId}/query`, {
+        method: 'POST',
+        headers: notionHeaders,
+        body: JSON.stringify({
+          filter: {
+            property: 'Stripe Price ID',
+            rich_text: { equals: price.id },
+          },
+        }),
+      }).then((r) => r.json());
+      const props: any = {
+        Name: { title: [{ text: { content: name } }] },
+        Price: { number: price.unit_amount ? price.unit_amount / 100 : 0 },
+        Currency: { select: { name: price.currency.toUpperCase() } },
+        Active: { checkbox: price.active },
+        'Stripe Product ID': { rich_text: [{ text: { content: String(price.product) } }] },
+        'Stripe Price ID': { rich_text: [{ text: { content: price.id } }] },
+        'Date Updated': { date: { start: new Date().toISOString() } },
+      };
+      if (query.results && query.results[0]) {
+        await fetch(`https://api.notion.com/v1/pages/${query.results[0].id}`, {
+          method: 'PATCH',
+          headers: notionHeaders,
+          body: JSON.stringify({ properties: props }),
+        });
+      } else {
+        await fetch('https://api.notion.com/v1/pages', {
+          method: 'POST',
+          headers: notionHeaders,
+          body: JSON.stringify({
+            parent: { database_id: dbId },
+            properties: props,
+          }),
+        });
+      }
+      updated++;
+    }
+    return { ok: true, updated };
+  },
+  'audit/prices': async (_payload, env) => {
+    if (!env.STRIPE_SECRET_KEY || !env.NOTION_TOKEN || !env.NOTION_DATABASE_ID) {
+      return { ok: false, error: 'missing env' };
+    }
+    const stripeHeaders = { Authorization: `Bearer ${env.STRIPE_SECRET_KEY}` };
+    const priceRes = await fetch('https://api.stripe.com/v1/prices?limit=100', { headers: stripeHeaders });
+    const prices = (await priceRes.json()).data || [];
+    const priceMap: Record<string, any> = {};
+    for (const p of prices) priceMap[p.id] = p;
+
+    const notionHeaders = {
+      Authorization: `Bearer ${env.NOTION_TOKEN}`,
+      'Notion-Version': '2022-06-28',
+      'Content-Type': 'application/json',
+    };
+    const dbId = env.NOTION_DATABASE_ID;
+    const diffs: any[] = [];
+    let cursor: string | undefined = undefined;
+    while (true) {
+      const query = await fetch(`https://api.notion.com/v1/databases/${dbId}/query`, {
+        method: 'POST',
+        headers: notionHeaders,
+        body: JSON.stringify({ start_cursor: cursor }),
+      }).then((r) => r.json());
+      for (const page of query.results || []) {
+        const props: any = page.properties || {};
+        const priceId = props['Stripe Price ID']?.rich_text?.[0]?.plain_text;
+        const notionPrice = props['Price']?.number;
+        if (priceId && priceMap[priceId]) {
+          const stripePrice = priceMap[priceId].unit_amount ? priceMap[priceId].unit_amount / 100 : 0;
+          if (stripePrice !== notionPrice) {
+            diffs.push({ priceId, stripe: stripePrice, notion: notionPrice });
+          }
+        }
+      }
+      if (!query.has_more) break;
+      cursor = query.next_cursor;
+    }
+    return { ok: true, diffs };
+  },
+  'tally/ingest': async (payload, env) => {
+    if (env.TALLY_WEBHOOK_SECRET && payload?.secret !== env.TALLY_WEBHOOK_SECRET) {
+      return { ok: false, error: 'unauthorized' };
+    }
+    // placeholder for later logic
+    return { ok: true };
+  },
+};
+
+export async function runAgent(name: string, payload: AgentPayload, env: AgentEnv) {
+  const fn = agents[name];
+  if (!fn) {
+    return { ok: false, error: `unknown agent: ${name}` };
+  }
+  try {
+    return await fn(payload, env);
+  } catch (err: any) {
+    return { ok: false, error: err.message };
+  }
+}
+
+export const agentNames = Object.keys(agents);

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,0 +1,102 @@
+import { runAgent } from '../agent/dispatcher';
+
+export default {
+  async fetch(request: Request, env: Record<string, any>): Promise<Response> {
+    const url = new URL(request.url);
+    const { pathname } = url;
+    const method = request.method;
+
+    const GOOGLE_PRIVATE_KEY =
+      (env.GOOGLE_PRIVATE_KEY_P1 || '') +
+      (env.GOOGLE_PRIVATE_KEY_P2 || '') +
+      (env.GOOGLE_PRIVATE_KEY_P3 || '') +
+      (env.GOOGLE_PRIVATE_KEY_P4 || '');
+
+    const cors = {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Content-Type, X-Fetch-Pass, tally-webhook-secret',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    };
+
+    if (method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: cors });
+    }
+
+    const json = (obj: any, status = 200) =>
+      new Response(JSON.stringify(obj), {
+        status,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
+
+    // optional agent gate
+    if (pathname.startsWith('/agent') && env.FETCH_PASS) {
+      const pass = request.headers.get('X-Fetch-Pass');
+      if (pass !== env.FETCH_PASS) {
+        return json({ ok: false, error: 'forbidden' }, 401);
+      }
+    }
+
+    if (pathname === '/health' && method === 'GET') {
+      return json({ ok: true, worker: 'online' });
+    }
+
+    // Telegram webhook
+    if (pathname === '/api/telegram' && method === 'POST') {
+      const update = await request.json();
+      const message: string = update?.message?.text || '';
+      const chatId = update?.message?.chat?.id;
+      const reply = async (text: string) => {
+        if (!env.TELEGRAM_BOT_TOKEN || !chatId) return;
+        await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ chat_id: chatId, text }),
+        });
+      };
+      if (message.startsWith('/ping')) {
+        await reply('pong');
+      } else if (message.startsWith('/help')) {
+        await reply('Commands: /ping, /sync, /audit');
+      } else if (message.startsWith('/sync')) {
+        const r = await fetch(new URL('/agent/sync/stripe-to-notion', request.url).toString(), {
+          method: 'POST',
+          headers: env.FETCH_PASS ? { 'X-Fetch-Pass': env.FETCH_PASS } : undefined,
+        });
+        const j = await r.json().catch(() => ({ ok: false }));
+        await reply(j.ok ? 'Sync complete' : 'Sync failed');
+      } else if (message.startsWith('/audit')) {
+        const r = await fetch(new URL('/agent/audit/prices', request.url).toString(), {
+          method: 'POST',
+          headers: env.FETCH_PASS ? { 'X-Fetch-Pass': env.FETCH_PASS } : undefined,
+        });
+        const j = await r.json().catch(() => ({ ok: false }));
+        await reply(j.ok ? 'Audit complete' : 'Audit failed');
+      }
+      return json({ ok: true });
+    }
+
+    if (pathname === '/agent/sync/stripe-to-notion' && method === 'POST') {
+      const payload = await request.json().catch(() => ({}));
+      const result = await runAgent('sync/stripe-to-notion', payload, env);
+      return json(result, result.ok ? 200 : 500);
+    }
+
+    if (pathname === '/agent/audit/prices' && method === 'POST') {
+      const payload = await request.json().catch(() => ({}));
+      const result = await runAgent('audit/prices', payload, env);
+      return json(result, result.ok ? 200 : 500);
+    }
+
+    if (pathname === '/agent/tally/ingest' && method === 'POST') {
+      const sig = request.headers.get('tally-webhook-secret');
+      if (env.TALLY_WEBHOOK_SECRET && sig !== env.TALLY_WEBHOOK_SECRET) {
+        return json({ ok: false, error: 'unauthorized' }, 401);
+      }
+      const payload = await request.json().catch(() => ({}));
+      const result = await runAgent('tally/ingest', payload, env);
+      return json(result, result.ok ? 200 : 500);
+    }
+
+    return new Response('Not found', { status: 404, headers: cors });
+  },
+};


### PR DESCRIPTION
## Summary
- add Cloudflare Worker endpoints and dispatcher for sync, audit, and tally agents
- expose health, stripe, and tally routes on Vercel and update check page
- provide operations guide and dev check script

## Testing
- `node scripts/dev-check.mjs` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9da4d3c8327a6b1183bf741a713