### PR TITLE
Add donor portal sync and email-first workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.log
+.runtime/

--- a/app/api/donors/health/route.ts
+++ b/app/api/donors/health/route.ts
@@ -1,0 +1,19 @@
+import fs from 'fs/promises';
+
+export const runtime = 'nodejs';
+
+async function readDonorDbId() {
+  if (process.env.DONORS_DATABASE_ID) return process.env.DONORS_DATABASE_ID;
+  try {
+    const data = JSON.parse(await fs.readFile('.runtime/notion.json', 'utf8'));
+    return data.DONORS_DATABASE_ID || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET() {
+  const hasSecret = Boolean(process.env.STRIPE_WEBHOOK_SECRET);
+  const dbId = await readDonorDbId();
+  return Response.json({ ok: true, webhookConfigured: hasSecret && !!dbId });
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { Client } from '@notionhq/client';
+import fs from 'fs/promises';
+
+export const runtime = 'nodejs';
+
+async function getDonorDbId(notion: Client): Promise<string> {
+  const envId = process.env.DONORS_DATABASE_ID;
+  if (envId) return envId;
+  try {
+    const data = JSON.parse(await fs.readFile('.runtime/notion.json', 'utf8'));
+    if (data.DONORS_DATABASE_ID) return data.DONORS_DATABASE_ID;
+  } catch {}
+  const parent = process.env.NOTION_HQ_PAGE_ID;
+  if (!parent) throw new Error('missing NOTION_HQ_PAGE_ID');
+  const res = await notion.databases.create({
+    parent: { page_id: parent },
+    title: [{ type: 'text', text: { content: 'Donors' } }],
+    properties: {
+      Donor: { title: {} },
+      Email: { email: {} },
+      Amount: { number: {} },
+      Currency: { select: { options: [] } },
+      StripeID: { rich_text: {} },
+      Date: { date: {} },
+      'Message/Note': { rich_text: {} }
+    }
+  });
+  await fs.mkdir('.runtime', { recursive: true });
+  await fs.writeFile('.runtime/notion.json', JSON.stringify({ DONORS_DATABASE_ID: res.id }));
+  return res.id;
+}
+
+async function upsertDonor(
+  notion: Client,
+  dbId: string,
+  data: { name: string; email: string; amount: number; currency: string; stripeId: string; message?: string; date: number }
+) {
+  const { name, email, amount, currency, stripeId, message, date } = data;
+  const q = await notion.databases.query({
+    database_id: dbId,
+    filter: { property: 'StripeID', rich_text: { equals: stripeId } }
+  });
+  const props: any = {
+    Donor: { title: [{ text: { content: name || 'Anonymous' } }] },
+    Email: { email: email || '' },
+    Amount: { number: amount },
+    Currency: { select: { name: currency.toUpperCase() } },
+    StripeID: { rich_text: [{ text: { content: stripeId } }] },
+    Date: { date: { start: new Date(date).toISOString() } },
+    'Message/Note': { rich_text: message ? [{ text: { content: message } }] : [] }
+  };
+  if (q.results[0]) {
+    await notion.pages.update({ page_id: q.results[0].id, properties: props });
+  } else {
+    await notion.pages.create({ parent: { database_id: dbId }, properties: props });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+  const stripeKey = process.env.STRIPE_SECRET_KEY;
+  const notionToken = process.env.NOTION_TOKEN;
+  if (!secret || !stripeKey || !notionToken) {
+    return NextResponse.json({ ok: false, error: 'missing-env' }, { status: 500 });
+  }
+  const payload = await req.text();
+  const sig = req.headers.get('stripe-signature') || '';
+  let event: Stripe.Event;
+  try {
+    const stripe = new Stripe(stripeKey, { apiVersion: '2023-10-16' });
+    event = stripe.webhooks.constructEvent(payload, sig, secret);
+  } catch (e: any) {
+    return new NextResponse('invalid signature', { status: 400 });
+  }
+  const notion = new Client({ auth: notionToken });
+  const dbId = await getDonorDbId(notion);
+  const obj: any = event.data.object;
+  if (event.type === 'checkout.session.completed' || event.type === 'payment_intent.succeeded') {
+    const amount = (obj.amount_total || obj.amount_received || obj.amount || 0) / 100;
+    const currency = (obj.currency || 'usd') as string;
+    const name = obj.customer_details?.name || obj.shipping?.name || '';
+    const email = obj.customer_details?.email || obj.receipt_email || '';
+    const stripeId = obj.id || obj.payment_intent || '';
+    const message = obj.metadata?.message || obj.metadata?.note;
+    const date = (obj.created || Math.floor(Date.now() / 1000)) * 1000;
+    await upsertDonor(notion, dbId, { name, email, amount, currency, stripeId, message, date });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -1,0 +1,34 @@
+import { google } from 'googleapis';
+import { requireEnv } from './env.js';
+import { fetchGoogleKey } from './google-key.js';
+
+async function getAuth() {
+  const client_email = requireEnv('GOOGLE_CLIENT_EMAIL');
+  const private_key = (await fetchGoogleKey()).replace(/\\n/g, '\n');
+  return new google.auth.JWT(client_email, undefined, private_key, [
+    'https://www.googleapis.com/auth/gmail.send'
+  ]);
+}
+
+export async function sendEmail({ to, subject, text }: { to: string; subject: string; text: string }) {
+  const auth = await getAuth();
+  const gmail = google.gmail({ version: 'v1', auth });
+  const message = [
+    `To: ${to}`,
+    'Content-Type: text/plain; charset=utf-8',
+    'MIME-Version: 1.0',
+    `Subject: ${subject}`,
+    '',
+    text,
+  ].join('\n');
+  const encodedMessage = Buffer.from(message)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  const res = await gmail.users.messages.send({
+    userId: 'me',
+    requestBody: { raw: encodedMessage },
+  });
+  return res.data;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,13 @@
 {
-  "version": 2,
-  "builds": [
-    { "src": "next.config.js", "use": "@vercel/next" }
+  "rewrites": [
+    { "source": "/check", "destination": "/check.html" }
   ],
-  "routes": [
-    { "src": "/(.*)", "dest": "/" }
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add Gmail sendEmail helper
- wire worker for email-first land replies and marking
- sync Stripe webhook donations into Notion and expose donors health endpoint
- rewrite Vercel /check route to static page and set referrer policy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb8f6311483278b8bf43cf51f9b06