### PR TITLE
feat: add profile export and sharing endpoints

### DIFF
--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,0 +1,108 @@
+import { Client } from '@notionhq/client';
+
+let cache: { data: Record<string, any>; ts: number } = { data: {}, ts: 0 };
+
+export async function ensureProfileDb(env: any) {
+  if (env.PROFILE_DB_ID) return env.PROFILE_DB_ID;
+  if (!env.NOTION_TOKEN || !env.NOTION_HQ_PAGE_ID) return null;
+  const notion = new Client({ auth: env.NOTION_TOKEN });
+  try {
+    const search = await notion.search({
+      query: 'Profile',
+      filter: { property: 'object', value: 'database' },
+    });
+    const existing: any = (search.results || []).find(
+      (r: any) => r?.parent?.page_id === env.NOTION_HQ_PAGE_ID
+    );
+    if (existing) {
+      env.PROFILE_DB_ID = existing.id;
+      return existing.id;
+    }
+    const db = await notion.databases.create({
+      parent: { page_id: env.NOTION_HQ_PAGE_ID },
+      title: [{ type: 'text', text: { content: 'Profile' } }],
+      properties: {
+        Key: { title: {} },
+        Value: { rich_text: {} },
+        Category: { select: { options: [] } },
+        Visibility: {
+          select: { options: [{ name: 'internal' }, { name: 'shareable' }] },
+        },
+        Updated: { date: {} },
+      },
+    });
+    env.PROFILE_DB_ID = db.id;
+    return db.id;
+  } catch (e) {
+    console.warn('ensureProfileDb failed', e);
+    return null;
+  }
+}
+
+async function fetchProfile(env: any) {
+  const dbId = env.PROFILE_DB_ID;
+  if (!dbId || !env.NOTION_TOKEN) return {};
+  const notion = new Client({ auth: env.NOTION_TOKEN });
+  const res = await notion.databases.query({ database_id: dbId, page_size: 100 });
+  const map: Record<string, { value: string; visibility: string }> = {};
+  for (const page of res.results as any[]) {
+    const key = page.properties?.Key?.title?.[0]?.plain_text || '';
+    if (!key) continue;
+    const value = (page.properties?.Value?.rich_text || [])
+      .map((t: any) => t.plain_text)
+      .join('');
+    const visibility = page.properties?.Visibility?.select?.name || 'internal';
+    map[key] = { value, visibility };
+  }
+  return map;
+}
+
+export async function getProfileMap(env: any) {
+  if (cache.data && Date.now() - cache.ts < 60_000) return cache.data;
+  const map = await fetchProfile(env);
+  cache = { data: map, ts: Date.now() };
+  return map;
+}
+
+export async function getShareableProfile(env: any) {
+  const map = await getProfileMap(env);
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(map)) {
+    if ((v as any).visibility === 'shareable') out[k] = (v as any).value;
+  }
+  return out;
+}
+
+export function maskEmail(email: string) {
+  const [user, domain] = email.split('@');
+  if (!user || !domain) return email;
+  if (user.length <= 2) return `${user[0]}****@${domain}`;
+  return `${user[0]}****${user[user.length - 1]}@${domain}`;
+}
+
+export function buildExportPacket(map: Record<string, string>, opts?: { includePII?: boolean }) {
+  const includePII = opts?.includePII;
+  const packet: any = {
+    project: {
+      name: map.project_name || '',
+      description: map.project_description || '',
+      location: {
+        state: map.project_state || '',
+        county: map.project_county || '',
+        acreage: map.project_acreage || '',
+      },
+    },
+    org: {
+      nonprofit_status: map.org_nonprofit_status || '',
+      donate_url: map.org_donate_url || '',
+    },
+    founder: {
+      name: map.founder_name || '',
+      email: map.founder_email || '',
+    },
+    timestamp: new Date().toISOString(),
+    keys_included: Object.keys(map),
+  };
+  if (!includePII) packet.founder.email = maskEmail(packet.founder.email);
+  return packet;
+}

--- a/public/check.html
+++ b/public/check.html
@@ -14,6 +14,10 @@
       <button id="btn-sync">Sync</button> <span id="sync-status"></span>
       <button id="btn-audit">Audit</button> <span id="audit-status"></span>
     </div>
+    <div id="profile-ctl">
+      <button id="btn-share">Shareable Profile</button> <span id="share-count"></span>
+      <button id="btn-export">Download Export JSON</button>
+    </div>
     <p><a href="https://mags-assistant.vercel.app">Vercel Prod</a></p>
   </div>
 
@@ -96,6 +100,34 @@
     }
   });
 
+  document.getElementById('btn-share').addEventListener('click', async () => {
+    const tile = document.getElementById('profile-ctl');
+    const el = document.getElementById('share-count');
+    el.textContent = '…';
+    tile.style.backgroundColor = '';
+    try {
+      const headers = {};
+      if (window.FETCH_PASS) headers['X-Fetch-Pass'] = window.FETCH_PASS;
+      const r = await fetch(`${WORKER_BASE}/profile/share`, { headers });
+      const j = await r.json();
+      if (j.ok) {
+        el.textContent = j.count;
+        if (j.count >= 5) tile.style.backgroundColor = 'lightgreen';
+        else if (j.count > 0) tile.style.backgroundColor = 'khaki';
+      } else {
+        el.textContent = 'err';
+        tile.style.backgroundColor = 'lightcoral';
+      }
+    } catch (e) {
+      el.textContent = 'err';
+      tile.style.backgroundColor = 'lightcoral';
+    }
+  });
+
+  document.getElementById('btn-export').addEventListener('click', () => {
+    window.open(`${WORKER_BASE}/profile/export`, '_blank');
+  });
+
   // Kick off probe on load
   probeAll();
 </script>
@@ -103,6 +135,7 @@
 <style>
   #probes { line-height: 1.6; }
   #controls { margin-top: 1rem; }
+  #profile-ctl { margin-top: 1rem; }
   button { margin-right: .5rem }
 </style>
 </body>


### PR DESCRIPTION
## Summary
- add profile utilities for filtering shareable keys and building exports
- expose `/profile/share` and `/profile/export` protected routes with sanitized output
- extend system check page with profile tools and export downloader

## Testing
- `npm test`
- `node --check worker/index.js`

------
https://chatgpt.com/codex/tasks/task_e_689bbeb73f588327855293fd08f71e2b