### PR TITLE
feat: add diagnostic status endpoints

### DIFF
--- a/api/admin/profile.js
+++ b/api/admin/profile.js
@@ -1,0 +1,26 @@
+import { env } from '../../lib/env.js';
+import { notion } from '../../lib/notion.js';
+import { ensureProfileDb } from '../../lib/notion_profile.js';
+
+export default async function(req, res) {
+  if (req.method !== 'GET') return res.status(405).json({ ok: false });
+  if (!env.NOTION_TOKEN) return res.json({ ok: false, reason: 'missing NOTION_TOKEN' });
+  const hq = env.NOTION_HQ_PAGE_ID;
+  if (!hq) return res.json({ ok: false, reason: 'missing NOTION_HQ_PAGE_ID' });
+  try {
+    const dbId = await ensureProfileDb({ notion, hqPageId: hq });
+    const r = await notion.databases.query({ database_id: dbId, page_size: 100 });
+    const items = r.results.map((p) => {
+      const props = p.properties || {};
+      return {
+        id: p.id,
+        key: props.Key?.title?.[0]?.plain_text || '',
+        value: props.Value?.rich_text?.[0]?.plain_text || '',
+        visibility: props.Visibility?.select?.name || '',
+      };
+    });
+    res.json({ ok: true, items });
+  } catch (e) {
+    res.json({ ok: false, reason: e.message });
+  }
+}

--- a/api/cron/daily.js
+++ b/api/cron/daily.js
@@ -1,0 +1,11 @@
+import { env } from '../../lib/env.js';
+
+function ok(res, data={}){ res.status(200).json({ ok: true, ...data }); }
+function bad(res, reason){ res.status(401).json({ ok: false, reason }); }
+
+export default async function(req, res) {
+  const url = new URL(req.url, 'http://x');
+  const secret = url.searchParams.get('secret');
+  if (!secret || secret !== env.CRON_SECRET) return bad(res, 'unauthorized');
+  ok(res);
+}

--- a/api/cron/digest.js
+++ b/api/cron/digest.js
@@ -1,0 +1,21 @@
+import { env } from '../../lib/env.js';
+
+function ok(res, data={}){ res.status(200).json({ ok: true, ...data }); }
+function bad(res, reason){ res.status(401).json({ ok: false, reason }); }
+
+export default async function(req, res) {
+  const url = new URL(req.url, 'http://x');
+  const secret = url.searchParams.get('secret');
+  if (secret !== env.CRON_SECRET) return bad(res, 'unauthorized');
+  const test = url.searchParams.get('test') === 'true';
+  if (env.TELEGRAM_BOT_TOKEN && env.TELEGRAM_CHAT_ID) {
+    try {
+      await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: env.TELEGRAM_CHAT_ID, text: `digest${test ? ' test' : ''}` }),
+      });
+    } catch {}
+  }
+  ok(res);
+}

--- a/api/cron/gmail-scan.js
+++ b/api/cron/gmail-scan.js
@@ -1,0 +1,11 @@
+import { env } from '../../lib/env.js';
+
+function ok(res, data={}){ res.status(200).json({ ok: true, ...data }); }
+function bad(res, reason){ res.status(401).json({ ok: false, reason }); }
+
+export default async function(req, res) {
+  const url = new URL(req.url, 'http://x');
+  const secret = url.searchParams.get('secret');
+  if (secret !== env.CRON_SECRET) return bad(res, 'unauthorized');
+  ok(res);
+}

--- a/api/cron/stripe-poll.js
+++ b/api/cron/stripe-poll.js
@@ -1,0 +1,11 @@
+import { env } from '../../lib/env.js';
+
+function ok(res, data={}){ res.status(200).json({ ok: true, ...data }); }
+function bad(res, reason){ res.status(401).json({ ok: false, reason }); }
+
+export default async function(req, res) {
+  const url = new URL(req.url, 'http://x');
+  const secret = url.searchParams.get('secret');
+  if (secret !== env.CRON_SECRET) return bad(res, 'unauthorized');
+  ok(res);
+}

--- a/api/diag/cron.js
+++ b/api/diag/cron.js
@@ -1,0 +1,20 @@
+import { env } from '../../lib/env.js';
+
+export default async function(req, res) {
+  const secret = env.CRON_SECRET;
+  const next_steps = [];
+  if (!secret) {
+    next_steps.push('Set CRON_SECRET');
+    return res.json({ ok: false, reason: 'missing CRON_SECRET', next_steps });
+  }
+  const base = process.env.API_BASE || '';
+  const mk = (p) => `${base}/api/cron/${p}?secret=${secret}`;
+  res.json({
+    ok: true,
+    urls: {
+      daily: mk('daily'),
+      'stripe-poll': mk('stripe-poll'),
+      'gmail-scan': mk('gmail-scan'),
+    },
+  });
+}

--- a/api/diag/drive.js
+++ b/api/diag/drive.js
@@ -1,0 +1,21 @@
+import { google } from 'googleapis';
+
+export default async function(req, res) {
+  const next_steps = [];
+  const email = process.env.GOOGLE_SERVICE_EMAIL;
+  const key = process.env.GOOGLE_PRIVATE_KEY;
+  if (!email || !key) {
+    next_steps.push('Set GOOGLE_SERVICE_EMAIL and GOOGLE_PRIVATE_KEY');
+    return res.json({ ok: false, reason: 'missing service account', next_steps });
+  }
+  try {
+    const auth = new google.auth.JWT(email, null, key.replace(/\\n/g, '\n'), [
+      'https://www.googleapis.com/auth/drive.metadata.readonly',
+    ]);
+    const drive = google.drive({ version: 'v3', auth });
+    await drive.files.list({ pageSize: 1, fields: 'files(id)' });
+    return res.json({ ok: true });
+  } catch (e) {
+    return res.json({ ok: false, reason: e.message, next_steps });
+  }
+}

--- a/api/diag/gmail.js
+++ b/api/diag/gmail.js
@@ -1,0 +1,19 @@
+export default async function(req, res) {
+  const next_steps = [];
+  const url = process.env.GMAIL_BRIDGE_URL;
+  const secret = process.env.APPS_SCRIPT_SECRET;
+  if (!url || !secret) {
+    if (!url) next_steps.push('Set GMAIL_BRIDGE_URL');
+    if (!secret) next_steps.push('Set APPS_SCRIPT_SECRET');
+    return res.json({ ok: false, reason: 'missing bridge config', next_steps });
+  }
+  try {
+    const r = await fetch(`${url.replace(/\/$/, '')}/ping`, {
+      headers: { Authorization: `Bearer ${secret}` },
+    });
+    const j = await r.json().catch(() => ({}));
+    return res.json({ ok: r.ok && j.ok });
+  } catch (e) {
+    return res.json({ ok: false, reason: e.message, next_steps });
+  }
+}

--- a/api/diag/health.js
+++ b/api/diag/health.js
@@ -1,0 +1,3 @@
+export default async function(req, res) {
+  res.status(200).json({ ok: true, time: new Date().toISOString() });
+}

--- a/api/diag/notion.js
+++ b/api/diag/notion.js
@@ -1,0 +1,36 @@
+import { env } from '../../lib/env.js';
+import { notion } from '../../lib/notion.js';
+import { ensureProfileDb } from '../../lib/notion_profile.js';
+
+export default async function(req, res) {
+  const next_steps = [];
+  if (!env.NOTION_TOKEN) {
+    next_steps.push('Set NOTION_TOKEN');
+    return res.json({ ok: false, reason: 'missing NOTION_TOKEN', next_steps });
+  }
+  const hq = env.NOTION_HQ_PAGE_ID;
+  if (!hq) {
+    next_steps.push('Set NOTION_HQ_PAGE_ID');
+    return res.json({ ok: false, reason: 'missing NOTION_HQ_PAGE_ID', next_steps });
+  }
+  try {
+    const profileDbId = await ensureProfileDb({ notion, hqPageId: hq });
+    let write = true;
+    try {
+      const page = await notion.pages.create({
+        parent: { database_id: profileDbId },
+        properties: {
+          Key: { title: [{ text: { content: 'diag-test' } }] },
+          Value: { rich_text: [{ text: { content: 'temp' } }] },
+        },
+      });
+      await notion.blocks.delete?.({ block_id: page.id }).catch(() => notion.pages.update({ page_id: page.id, archived: true }));
+    } catch (e) {
+      write = false;
+      next_steps.push('Open the HQ page in Notion → ••• → Add connections → pick Maggie/Mags Assistant → Can edit. If a “Profile” DB exists, open it → ••• → Add connections → pick Maggie.');
+    }
+    return res.json({ ok: true, profileDbId, write, next_steps });
+  } catch (e) {
+    return res.json({ ok: false, reason: e.message, next_steps });
+  }
+}

--- a/api/diag/stripe.js
+++ b/api/diag/stripe.js
@@ -1,0 +1,20 @@
+import { env } from '../../lib/env.js';
+import Stripe from 'stripe';
+
+export default async function(req, res) {
+  const next_steps = [];
+  if (!env.STRIPE_SECRET_KEY) {
+    next_steps.push('Set STRIPE_SECRET_KEY');
+    return res.json({ ok: false, reason: 'missing STRIPE_SECRET_KEY', next_steps });
+  }
+  const stripe = new Stripe(env.STRIPE_SECRET_KEY);
+  try {
+    await stripe.balance.retrieve();
+    await stripe.products.list({ limit: 1 });
+  } catch (e) {
+    return res.json({ ok: false, reason: e.message, next_steps });
+  }
+  const webhookSet = !!env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSet) next_steps.push('Set STRIPE_WEBHOOK_SECRET');
+  res.json({ ok: true, webhook: webhookSet, next_steps });
+}

--- a/api/diag/telegram.js
+++ b/api/diag/telegram.js
@@ -1,0 +1,27 @@
+import { env } from '../../lib/env.js';
+
+export default async function(req, res) {
+  const next_steps = [];
+  if (!env.TELEGRAM_BOT_TOKEN) {
+    next_steps.push('Set TELEGRAM_BOT_TOKEN');
+    return res.json({ ok: false, reason: 'missing TELEGRAM_BOT_TOKEN', next_steps });
+  }
+  const url = new URL(req.url, 'http://x');
+  const send = url.searchParams.get('send') === 'true';
+  if (send) {
+    if (!env.TELEGRAM_CHAT_ID) {
+      next_steps.push('Set TELEGRAM_CHAT_ID');
+      return res.json({ ok: false, reason: 'missing TELEGRAM_CHAT_ID', next_steps });
+    }
+    try {
+      await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: env.TELEGRAM_CHAT_ID, text: 'diag ping' }),
+      });
+    } catch (e) {
+      return res.json({ ok: false, reason: e.message, next_steps });
+    }
+  }
+  res.json({ ok: true, sent: send });
+}

--- a/api/gmail/nudge.js
+++ b/api/gmail/nudge.js
@@ -1,0 +1,24 @@
+export default async function(req, res) {
+  const url = process.env.GMAIL_BRIDGE_URL;
+  const secret = process.env.APPS_SCRIPT_SECRET;
+  const next_steps = [];
+  if (!url || !secret) {
+    if (!url) next_steps.push('Set GMAIL_BRIDGE_URL');
+    if (!secret) next_steps.push('Set APPS_SCRIPT_SECRET');
+    return res.json({ ok: false, reason: 'missing bridge config', next_steps });
+  }
+  try {
+    const r = await fetch(`${url.replace(/\/$/, '')}/nudge`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${secret}`,
+      },
+      body: JSON.stringify(req.body || {}),
+    });
+    const data = await r.json().catch(() => ({}));
+    res.json({ ok: r.ok, data });
+  } catch (e) {
+    res.json({ ok: false, reason: e.message, next_steps });
+  }
+}

--- a/api/gmail/scan.js
+++ b/api/gmail/scan.js
@@ -1,0 +1,24 @@
+export default async function(req, res) {
+  const url = process.env.GMAIL_BRIDGE_URL;
+  const secret = process.env.APPS_SCRIPT_SECRET;
+  const next_steps = [];
+  if (!url || !secret) {
+    if (!url) next_steps.push('Set GMAIL_BRIDGE_URL');
+    if (!secret) next_steps.push('Set APPS_SCRIPT_SECRET');
+    return res.json({ ok: false, reason: 'missing bridge config', next_steps });
+  }
+  try {
+    const r = await fetch(`${url.replace(/\/$/, '')}/scan`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${secret}`,
+      },
+      body: JSON.stringify(req.body || {}),
+    });
+    const data = await r.json().catch(() => ({}));
+    res.json({ ok: r.ok, data });
+  } catch (e) {
+    res.json({ ok: false, reason: e.message, next_steps });
+  }
+}

--- a/api/router.js
+++ b/api/router.js
@@ -105,6 +105,62 @@ export default async function handler(req, res) {
   try {
     const { pathname } = new URL(url, `http://${req.headers.host}`);
 
+    // dynamic modules for new api routes
+    if (pathname.startsWith('/api/diag/')) {
+      const name = pathname.slice('/api/diag/'.length);
+      try {
+        const mod = await import(`./diag/${name}.js`);
+        await mod.default(req, res);
+      } catch {
+        bad(res, 'Not found', 404);
+      }
+      return;
+    }
+
+    if (pathname.startsWith('/api/gmail/')) {
+      const name = pathname.slice('/api/gmail/'.length);
+      try {
+        const mod = await import(`./gmail/${name}.js`);
+        await mod.default(req, res);
+      } catch {
+        bad(res, 'Not found', 404);
+      }
+      return;
+    }
+
+    if (pathname.startsWith('/api/stripe/')) {
+      const name = pathname.slice('/api/stripe/'.length);
+      try {
+        const mod = await import(`./stripe/${name}.js`);
+        await mod.default(req, res);
+      } catch {
+        bad(res, 'Not found', 404);
+      }
+      return;
+    }
+
+    if (pathname.startsWith('/api/cron/')) {
+      const name = pathname.slice('/api/cron/'.length);
+      try {
+        const mod = await import(`./cron/${name}.js`);
+        await mod.default(req, res);
+      } catch {
+        bad(res, 'Not found', 404);
+      }
+      return;
+    }
+
+    if (pathname.startsWith('/api/admin/')) {
+      const name = pathname.slice('/api/admin/'.length);
+      try {
+        const mod = await import(`./admin/${name}.js`);
+        await mod.default(req, res);
+      } catch {
+        bad(res, 'Not found', 404);
+      }
+      return;
+    }
+
     // health / diag
     if (pathname === '/api/hello') return ok(res, { hello: 'mags' });
     if (pathname === '/api/health' && method === 'GET') {

--- a/api/stripe/audit.js
+++ b/api/stripe/audit.js
@@ -1,0 +1,17 @@
+import { env } from '../../lib/env.js';
+import Stripe from 'stripe';
+
+export default async function(req, res) {
+  const next_steps = [];
+  if (!env.STRIPE_SECRET_KEY) {
+    next_steps.push('Set STRIPE_SECRET_KEY');
+    return res.json({ ok: false, reason: 'missing STRIPE_SECRET_KEY', next_steps });
+  }
+  const stripe = new Stripe(env.STRIPE_SECRET_KEY);
+  try {
+    await stripe.prices.list({ limit: 1 });
+    res.json({ ok: true });
+  } catch (e) {
+    res.json({ ok: false, reason: e.message, next_steps });
+  }
+}

--- a/api/stripe/webhook.js
+++ b/api/stripe/webhook.js
@@ -1,0 +1,25 @@
+import Stripe from 'stripe';
+import { env } from '../../lib/env.js';
+
+export default async function(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ ok: false });
+  const sig = req.headers['stripe-signature'];
+  const secret = env.STRIPE_WEBHOOK_SECRET;
+  if (!secret) return res.status(400).json({ ok: false, reason: 'no STRIPE_WEBHOOK_SECRET' });
+  const stripe = new Stripe(env.STRIPE_SECRET_KEY || '');
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.rawBody, sig, secret);
+  } catch (e) {
+    return res.status(400).json({ ok: false, reason: e.message });
+  }
+  switch (event.type) {
+    case 'checkout.session.completed':
+    case 'payment_intent.succeeded':
+      console.log('stripe event', event.type);
+      break;
+    default:
+      break;
+  }
+  res.json({ ok: true });
+}

--- a/lib/notion_profile.js
+++ b/lib/notion_profile.js
@@ -1,0 +1,68 @@
+import { promises as fs } from 'fs';
+import { join, dirname } from 'path';
+import { notion } from './notion.js';
+
+const LAST_IDS_PATH = join('docs', '.last-notion-ids.json');
+
+function getText(prop) {
+  return prop?.[0]?.plain_text || '';
+}
+
+export async function ensureProfileDb({ notion: client = notion, hqPageId }) {
+  if (!client || !hqPageId) return null;
+  const envId = process.env.NOTION_PROFILE_DB_ID;
+  if (envId) {
+    try {
+      await client.databases.retrieve({ database_id: envId });
+      return envId;
+    } catch {}
+  }
+  const search = await client.search({
+    query: 'Profile',
+    filter: { property: 'object', value: 'database' },
+    page_size: 50,
+  });
+  const existing = search.results.find(
+    (d) => d.parent?.page_id === hqPageId && getText(d.title) === 'Profile'
+  );
+  if (existing) {
+    await persistId(existing.id);
+    return existing.id;
+  }
+  const db = await client.databases.create({
+    parent: { page_id: hqPageId },
+    title: [{ type: 'text', text: { content: 'Profile' } }],
+    properties: {
+      Key: { title: {} },
+      Value: { rich_text: {} },
+      Category: { select: {} },
+      Visibility: {
+        select: {
+          options: [
+            { name: 'internal', color: 'blue' },
+            { name: 'shareable', color: 'green' },
+          ],
+        },
+      },
+      Updated: { last_edited_time: {} },
+    },
+  });
+  await persistId(db.id);
+  return db.id;
+}
+
+async function persistId(id) {
+  const payload = { profileDbId: id };
+  try {
+    let existing = {};
+    try {
+      const raw = await fs.readFile(LAST_IDS_PATH, 'utf8');
+      existing = JSON.parse(raw);
+    } catch {}
+    const data = { ...existing, ...payload };
+    await fs.mkdir(dirname(LAST_IDS_PATH), { recursive: true });
+    await fs.writeFile(LAST_IDS_PATH, JSON.stringify(data, null, 2));
+  } catch (e) {
+    console.warn('persistId error', e);
+  }
+}

--- a/public/check.html
+++ b/public/check.html
@@ -9,134 +9,58 @@
 <body>
   <div class="container">
     <h1>System Check</h1>
-    <ul id="probes"></ul>
-    <div id="controls">
-      <button id="btn-sync">Sync</button> <span id="sync-status"></span>
-      <button id="btn-audit">Audit</button> <span id="audit-status"></span>
-    </div>
-    <div id="profile-ctl">
-      <button id="btn-share">Shareable Profile</button> <span id="share-count"></span>
-      <button id="btn-export">Download Export JSON</button>
-    </div>
-    <p><a href="https://mags-assistant.vercel.app">Vercel Prod</a></p>
+    <div id="cards"></div>
+    <button id="btn-digest">Send test digest</button>
   </div>
-
 <script>
-  // --- CONFIG ---
-  const WORKER_BASE = 'https://tight-snow-2840.messyandmagnetic.workers.dev';
-  const ENDPOINTS = [
-    { name: 'Vercel /api/health', url: '/api/health' },
-    { name: 'Vercel /api/stripe', url: '/api/stripe', method: 'POST' },
-    { name: 'Worker /health', url: `${WORKER_BASE}/health` },
-    { name: 'Worker /agent/sync/stripe-to-notion', url: `${WORKER_BASE}/agent/sync/stripe-to-notion`, method: 'POST' },
-    { name: 'Worker /agent/audit/prices', url: `${WORKER_BASE}/agent/audit/prices`, method: 'POST' },
-  ];
-
-  // Optional: set this in DevTools for gated calls
-  // window.FETCH_PASS = 'your-secret';
-
-  function color(el, ok, msg) {
-    el.textContent = msg;
-    el.style.color = ok ? 'green' : 'crimson';
-  }
-
-  async function safeJSON(res) {
-    const txt = await res.text();
-    try   { return { ok: true, data: JSON.parse(txt) }; }
-    catch { return { ok: true, data: { raw: txt } }; }
-  }
-
-  async function probeAll() {
-    const ul = document.getElementById('probes');
-    ul.innerHTML = '';
-    for (const ep of ENDPOINTS) {
-      const li = document.createElement('li');
-      li.textContent = `${ep.name}: probing…`;
-      ul.appendChild(li);
-      try {
-        const r = await fetch(ep.url, { method: ep.method || 'GET', headers: ep.method === 'POST' ? {'Content-Type':'application/json'} : undefined, body: ep.method === 'POST' ? '{}' : undefined });
-        let msg = 'ok';
-        try { const j = await r.json(); msg = j.msg || j.type || (j.ok ? 'ok' : 'fail'); } catch {}
-        li.textContent = `${ep.name}: ${r.ok ? msg : `HTTP ${r.status}`}`;
-        li.style.color = r.ok ? 'green' : 'crimson';
-      } catch (e) {
-        li.textContent = `${ep.name}: network error`;
-        li.style.color = 'crimson';
+const CARDS=[
+  {name:'API Health',url:'/api/diag/health'},
+  {name:'Notion',url:'/api/diag/notion'},
+  {name:'Stripe',url:'/api/diag/stripe'},
+  {name:'Gmail',url:'/api/diag/gmail'},
+  {name:'Telegram',url:'/api/diag/telegram'},
+  {name:'Drive',url:'/api/diag/drive'},
+  {name:'Cron',url:'/api/diag/cron'}
+];
+async function run(){
+  const host=document.getElementById('cards');
+  for(const c of CARDS){
+    const div=document.createElement('div');
+    div.className='card';
+    div.textContent=c.name+': checking...';
+    host.appendChild(div);
+    try{
+      const r=await fetch(c.url);
+      const j=await r.json();
+      if(j.ok){
+        div.classList.add('ok');
+        div.textContent=c.name;
+      }else{
+        div.classList.add('fail');
+        div.textContent=c.name+': '+(j.reason||'error');
+        if(j.next_steps&&j.next_steps[0]){
+          const ns=document.createElement('div');
+          ns.className='next';
+          ns.textContent=j.next_steps[0];
+          div.appendChild(ns);
+        }
       }
+    }catch(e){
+      div.classList.add('fail');
+      div.textContent=c.name+': network error';
     }
   }
-
-  async function postJSON(url) {
-    const headers = { 'Content-Type': 'application/json' };
-    if (window.FETCH_PASS) headers['X-Fetch-Pass'] = window.FETCH_PASS;
-
-    const res = await fetch(url, { method: 'POST', headers, body: '{}' });
-    const body = await safeJSON(res);
-    return { ok: res.ok, data: body.data };
-  }
-
-  // Button wiring
-  document.getElementById('btn-sync').addEventListener('click', async () => {
-    const el = document.getElementById('sync-status');
-    color(el, true, 'syncing…');
-    try {
-      const { ok, data } = await postJSON(`${WORKER_BASE}/agent/sync/stripe-to-notion`);
-      color(el, ok, ok ? (data.msg || 'synced') : `sync failed`);
-      if (!ok) console.warn('sync error', data);
-    } catch (e) {
-      color(el, false, 'sync network error');
-    }
-  });
-
-  document.getElementById('btn-audit').addEventListener('click', async () => {
-    const el = document.getElementById('audit-status');
-    color(el, true, 'auditing…');
-    try {
-      const { ok, data } = await postJSON(`${WORKER_BASE}/agent/audit/prices`);
-      color(el, ok, ok ? (data.msg || 'audited') : `audit failed`);
-      if (!ok) console.warn('audit error', data);
-    } catch (e) {
-      color(el, false, 'audit network error');
-    }
-  });
-
-  document.getElementById('btn-share').addEventListener('click', async () => {
-    const tile = document.getElementById('profile-ctl');
-    const el = document.getElementById('share-count');
-    el.textContent = '…';
-    tile.style.backgroundColor = '';
-    try {
-      const headers = {};
-      if (window.FETCH_PASS) headers['X-Fetch-Pass'] = window.FETCH_PASS;
-      const r = await fetch(`${WORKER_BASE}/profile/share`, { headers });
-      const j = await r.json();
-      if (j.ok) {
-        el.textContent = j.count;
-        if (j.count >= 5) tile.style.backgroundColor = 'lightgreen';
-        else if (j.count > 0) tile.style.backgroundColor = 'khaki';
-      } else {
-        el.textContent = 'err';
-        tile.style.backgroundColor = 'lightcoral';
-      }
-    } catch (e) {
-      el.textContent = 'err';
-      tile.style.backgroundColor = 'lightcoral';
-    }
-  });
-
-  document.getElementById('btn-export').addEventListener('click', () => {
-    window.open(`${WORKER_BASE}/profile/export`, '_blank');
-  });
-
-  // Kick off probe on load
-  probeAll();
+}
+run();
+document.getElementById('btn-digest').addEventListener('click',()=>{
+  fetch('/api/cron/digest?test=true', {method:'POST'});
+});
 </script>
-
 <style>
-  #probes { line-height: 1.6; }
-  #controls { margin-top: 1rem; }
-  #profile-ctl { margin-top: 1rem; }
-  button { margin-right: .5rem }
+  .card{padding:10px;margin:6px;border:1px solid #ccc;}
+  .card.ok{background:#c7f5d9;}
+  .card.fail{background:#f5c7c7;}
+  .next{font-size:0.9em;margin-top:4px;}
 </style>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dynamic API routing for diagnostics, cron, stripe, gmail, and admin endpoints
- implement health, notion, stripe, telegram, drive, gmail, and cron diagnostics with human-friendly guidance
- add basic cron and gmail proxy endpoints and test digest sender
- build simple status page rendering green/red cards for each service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc90ba2708327b7ed2866cd8f0e1a