### PR TITLE
fix(vercel): remove legacy routes and migrate to rewrites/redirects/headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,17 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "functions": {
+    "api/**/*.ts": { "runtime": "nodejs" },
+    "api/**/*.js": { "runtime": "nodejs" }
+  },
+  "cleanUrls": true,
+  "trailingSlash": false,
   "rewrites": [
     { "source": "/check", "destination": "/check.html" },
     { "source": "/api/stripe-webhook", "destination": "/api/ops?action=stripe-webhook" }
   ],
+  "redirects": [],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- normalize vercel.json with schema, version, function runtimes, clean URLs and trailing slash handling
- ensure rewrites, redirects, and headers are top-level arrays and no legacy `routes`

## Testing
- `npx vercel --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*
- `npx vercel build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

## Manual Checklist
- [ ] In Vercel → Project → Settings → General, verify no UI-level "Redirects" conflict with this file.
- [ ] Redeploy Preview; test a migrated redirect, rewrite, and header path.
- [ ] Visit /api/ping to confirm function runtime still works.

------
https://chatgpt.com/codex/tasks/task_e_689c3fefc21c8327a9bf629547574616