### PR TITLE
chore: set Node 20 engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
 
   "engines": {
-    "node": ">=20 <23"
+    "node": "20.x"
   },
 
   "dependencies": {},


### PR DESCRIPTION
## Summary
- specify Node.js 20.x in root `package.json` to match Vercel settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx vercel --prod` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d0a399e408327b1e919c06c111164