### PR TITLE
ops: harden scheduled workflows and add Telegram alerts

### DIFF
--- a/.github/workflows/cron-runner.yml
+++ b/.github/workflows/cron-runner.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run:
-    if: env.USE_GH_CRON == 'true'
+    if: env.USE_GH_CRON == 'true' && env.API_BASE != '' && startsWith(env.API_BASE, 'http')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/drive-review.yml
+++ b/.github/workflows/drive-review.yml
@@ -3,11 +3,24 @@ on:
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:
+
 jobs:
   ping:
     runs-on: ubuntu-latest
+    env:
+      PROD_URL: ${{ secrets.PROD_URL }}
+      CRON_SECRET: ${{ secrets.CRON_SECRET }}
     steps:
-      - name: Call Vercel endpoint
+      - name: Check PROD_URL
+        id: check
         run: |
-          curl -fsS "https://assistant.messyandmagnetic.com/api/drive/review?token=${{ secrets.CRON_SECRET }}"
-
+          if [ -n "$PROD_URL" ] && curl -I -sS "$PROD_URL" | head -n 1 | grep -q "200"; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Prod URL missing or unreachable; skipping ping."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Call Vercel endpoint
+        if: steps.check.outputs.ok == 'true'
+        run: |
+          curl -fsS "$PROD_URL/api/drive/review?token=$CRON_SECRET"

--- a/.github/workflows/nightly-analytics.yml
+++ b/.github/workflows/nightly-analytics.yml
@@ -1,9 +1,24 @@
 name: Nightly analytics
 on:
   schedule: [{ cron: "15 7 * * *" }]
+  workflow_dispatch:
+
 jobs:
   run:
     runs-on: ubuntu-latest
+    env:
+      PROD_URL: ${{ secrets.PROD_URL }}
+      CRON_SECRET: ${{ secrets.CRON_SECRET }}
     steps:
+      - name: Check PROD_URL
+        id: check
+        run: |
+          if [ -n "$PROD_URL" ] && curl -I -sS "$PROD_URL" | head -n 1 | grep -q "200"; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Prod URL missing or unreachable; skipping analyze."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Hit analyze endpoint
-        run: curl -fsS "${{ secrets.PROD_URL }}/api/social/analyze?token=${{ secrets.CRON_SECRET }}"
+        if: steps.check.outputs.ok == 'true'
+        run: curl -fsS "$PROD_URL/api/social/analyze?token=$CRON_SECRET"

--- a/.github/workflows/nightly-trends.yml
+++ b/.github/workflows/nightly-trends.yml
@@ -13,11 +13,25 @@ jobs:
       NOTION_DB_TRENDS: ${{ secrets.NOTION_DB_TRENDS }}
       WORKER_URL: ${{ secrets.WORKER_URL }}
     steps:
+      - name: Check dependencies
+        id: deps
+        run: |
+          missing=""
+          [ -z "$NOTION_DB_TRENDS" ] && missing="NOTION_DB_TRENDS"
+          [ -z "$WORKER_URL" ] && missing="$missing WORKER_URL"
+          if [ -n "$missing" ]; then
+            echo "Missing $missing; skipping trends." 
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@v4
+        if: steps.deps.outputs.ok == 'true'
       - name: Fetch trends
+        if: steps.deps.outputs.ok == 'true'
         run: npx tsx scripts/trends.ts
       - name: Notify failure
-        if: failure()
+        if: failure() && steps.deps.outputs.ok == 'true' && env.WORKER_URL != '' && startsWith(env.WORKER_URL, 'http')
         run: |
           curl -sS -X POST "$WORKER_URL/api/notify" \
             -H "content-type: application/json" \

--- a/.github/workflows/preview-check.yml
+++ b/.github/workflows/preview-check.yml
@@ -37,3 +37,9 @@ jobs:
       - name: Preview unavailable
         if: steps.preview.outputs.url == ''
         run: echo 'No preview URL yet'
+      - name: Notify failure
+        if: failure() && env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != ''
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: node scripts/notify.ts "❌ preview-check failed: $GITHUB_RUN_ID"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -118,3 +118,9 @@ jobs:
           fi
           echo "Pinging: $URL/api/ping"
           curl -sSf "$URL/api/ping" | tee /dev/stdout
+      - name: Notify failure
+        if: failure() && env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != ''
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: node scripts/notify.ts "❌ smoke failed: $GITHUB_RUN_ID"

--- a/scripts/notify.ts
+++ b/scripts/notify.ts
@@ -1,0 +1,22 @@
+import process from 'node:process';
+
+const token = process.env.TELEGRAM_BOT_TOKEN;
+const chat = process.env.TELEGRAM_CHAT_ID;
+const msg = process.argv.slice(2).join(' ');
+
+if (!token || !chat || !msg) {
+  console.error('missing telegram config or message');
+  process.exit(0);
+}
+
+fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ chat_id: chat, text: msg })
+})
+  .then(res => {
+    if (!res.ok) {
+      return res.text().then(t => console.error('telegram request failed', t));
+    }
+  })
+  .catch(err => console.error('telegram error', err));


### PR DESCRIPTION
## Summary
- gate cron-runner on valid API_BASE
- skip nightly jobs if required services missing
- wire Telegram notifications for smoke & preview failures

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d46e76f34832786caa770ee092d57