### PR TITLE
chore: solid system check + static health + resilient cron/skips

### DIFF
--- a/.github/workflows/cron-runner.yml
+++ b/.github/workflows/cron-runner.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   run:
-    if: env.USE_GH_CRON == 'true' && env.API_BASE != '' && startsWith(env.API_BASE, 'http')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -15,8 +14,19 @@ jobs:
       API_BASE: ${{ secrets.API_BASE }}
       CRON_SECRET: ${{ secrets.CRON_SECRET }}
     steps:
+      - name: Check cron flag
+        run: |
+          if [ "$USE_GH_CRON" != "true" ]; then
+            echo "skipped by USE_GH_CRON"
+            exit 0
+          fi
+      - name: Check API base
+        run: |
+          if [ -z "$API_BASE" ]; then
+            echo "API_BASE empty; skipping API calls"
+            exit 0
+          fi
       - name: Trigger scan
-        shell: bash
         run: |
           set -euo pipefail
           curl -sS -X POST "$API_BASE/api/commands/scan" \
@@ -26,7 +36,6 @@ jobs:
             | tee scan.json
       - name: Run due social posts
         if: env.API_BASE == 'https://mags-assistant.vercel.app'
-        shell: bash
         run: |
           set -euo pipefail
           curl -sS -X POST "$API_BASE/api/social/run-due" \

--- a/.github/workflows/nightly-analytics.yml
+++ b/.github/workflows/nightly-analytics.yml
@@ -7,18 +7,27 @@ jobs:
   run:
     runs-on: ubuntu-latest
     env:
-      PROD_URL: ${{ secrets.PROD_URL }}
+      API_BASE: ${{ secrets.API_BASE }}
       CRON_SECRET: ${{ secrets.CRON_SECRET }}
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
     steps:
-      - name: Check PROD_URL
-        id: check
+      - name: Compute API availability
         run: |
-          if [ -n "$PROD_URL" ] && curl -I -sS "$PROD_URL" | head -n 1 | grep -q "200"; then
-            echo "ok=true" >> "$GITHUB_OUTPUT"
+          if [ -n "$API_BASE" ]; then
+            echo "HAS_API=true" >> "$GITHUB_ENV"
           else
-            echo "Prod URL missing or unreachable; skipping analyze."
-            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "HAS_API=false" >> "$GITHUB_ENV"
           fi
       - name: Hit analyze endpoint
-        if: steps.check.outputs.ok == 'true'
-        run: curl -fsS "$PROD_URL/api/social/analyze?token=$CRON_SECRET"
+        if: env.HAS_API == 'true'
+        run: curl -fsS "$API_BASE/api/social/analyze?token=$CRON_SECRET"
+      - name: No API base
+        if: env.HAS_API != 'true'
+        run: echo "No API_BASE; skipping analytics"
+      - name: Telegram ping
+        if: env.HAS_API != 'true' && env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != ''
+        run: |
+          curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            -d text="nightly analytics skipped"

--- a/.github/workflows/nightly-trends.yml
+++ b/.github/workflows/nightly-trends.yml
@@ -9,30 +9,50 @@ jobs:
   run:
     runs-on: ubuntu-latest
     env:
+      API_BASE: ${{ secrets.API_BASE }}
       NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
       NOTION_DB_TRENDS: ${{ secrets.NOTION_DB_TRENDS }}
       WORKER_URL: ${{ secrets.WORKER_URL }}
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
     steps:
+      - name: Compute API availability
+        run: |
+          if [ -n "$API_BASE" ]; then
+            echo "HAS_API=true" >> "$GITHUB_ENV"
+          else
+            echo "HAS_API=false" >> "$GITHUB_ENV"
+          fi
       - name: Check dependencies
+        if: env.HAS_API == 'true'
         id: deps
         run: |
           missing=""
           [ -z "$NOTION_DB_TRENDS" ] && missing="NOTION_DB_TRENDS"
           [ -z "$WORKER_URL" ] && missing="$missing WORKER_URL"
           if [ -n "$missing" ]; then
-            echo "Missing $missing; skipping trends." 
+            echo "Missing $missing; skipping trends."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/checkout@v4
-        if: steps.deps.outputs.ok == 'true'
+        if: env.HAS_API == 'true' && steps.deps.outputs.ok == 'true'
       - name: Fetch trends
-        if: steps.deps.outputs.ok == 'true'
+        if: env.HAS_API == 'true' && steps.deps.outputs.ok == 'true'
         run: npx tsx scripts/trends.ts
       - name: Notify failure
-        if: failure() && steps.deps.outputs.ok == 'true' && env.WORKER_URL != '' && startsWith(env.WORKER_URL, 'http')
+        if: failure() && env.HAS_API == 'true' && steps.deps.outputs.ok == 'true' && env.WORKER_URL != '' && startsWith(env.WORKER_URL, 'http')
         run: |
           curl -sS -X POST "$WORKER_URL/api/notify" \
             -H "content-type: application/json" \
             -d '{"summary":"nightly trends failed"}'
+      - name: No API base
+        if: env.HAS_API != 'true'
+        run: echo 'No API_BASE; skipping trends'
+      - name: Telegram ping
+        if: env.HAS_API != 'true' && env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != ''
+        run: |
+          curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            -d text="nightly trends skipped"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,7 +6,6 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-# needed so the workflow can read repo and post a PR comment
 permissions:
   contents: read
   pull-requests: write
@@ -15,17 +14,10 @@ permissions:
 jobs:
   smoke:
     runs-on: ubuntu-latest
-
     env:
-      # Optional: set this in GitHub → Settings → Secrets and variables → Actions → Variables
-      # or as a Secret if you prefer.
-      # Example: https://mags-assistant.vercel.app
-      FALLBACK_PROD_URL: ${{ vars.VERCEL_PROD_URL }}
-
-      # Required to query Vercel API for previews
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
+      API_BASE: ${{ secrets.API_BASE }}
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,92 +27,31 @@ jobs:
         with:
           node-version: '20'
 
-      # --- Discover Vercel preview URL (if exists) ---
-      - name: Get Vercel Preview URL
-        id: preview
-        uses: actions/github-script@v7
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-          SHA: ${{ github.sha }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fetch = global.fetch || (await import('node-fetch')).default;
-
-            const token = process.env.VERCEL_TOKEN;
-            const project = process.env.VERCEL_PROJECT_ID;
-            if (!token || !project) {
-              core.info('No VERCEL_TOKEN or VERCEL_PROJECT_ID; skipping preview lookup.');
-              core.setOutput('url', '');
-              return;
-            }
-
-            // Try by git SHA first, then by branch (head_ref)
-            const base = `https://api.vercel.com/v6/deployments`;
-            const headers = { Authorization: `Bearer ${token}` };
-
-            async function findBy(query) {
-              const url = `${base}?projectId=${project}&${query}&limit=20`;
-              const res = await fetch(url, { headers });
-              if (!res.ok) return null;
-              const data = await res.json();
-              const ready = (data.deployments || []).find(d => d.readyState === 'READY');
-              if (!ready) return null;
-              if (ready.url) return `https://${ready.url}`;
-              return null;
-            }
-
-            let url = await findBy(`meta-gitSha=${process.env.SHA}`);
-            if (!url && process.env.HEAD_REF) {
-              url = await findBy(`meta-gitBranch=${encodeURIComponent(process.env.HEAD_REF)}`);
-            }
-
-            core.setOutput('url', url || '');
-            core.info(`Preview URL: ${url || '(none)'}`);
-
-      # --- Safely comment the preview URL on PRs (non-fatal, avoids 403 on forks) ---
-      - name: Comment preview URL (safe)
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.preview.outputs.url != '' }}
-        uses: actions/github-script@v7
-        continue-on-error: true
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: `Vercel preview: ${context.payload.repository.html_url ? '' : ''}${process.env['PREVIEW_URL'] || '${{ steps.preview.outputs.url }}'}`
-            });
-
-      # --- Decide which base URL to use for smoke test ---
-      - name: Decide URL
-        id: baseurl
+      - name: Compute API availability
         run: |
-          URL="${{ steps.preview.outputs.url }}"
-          if [ -z "$URL" ]; then
-            URL="${FALLBACK_PROD_URL}"
+          if [ -n "$API_BASE" ]; then
+            echo "HAS_API=true" >> "$GITHUB_ENV"
+          else
+            echo "HAS_API=false" >> "$GITHUB_ENV"
           fi
-          if [ -z "$URL" ]; then
-            # last resort: read from repo variable named PUBLIC_URL (optional)
-            URL="${{ vars.PUBLIC_URL }}"
-          fi
-          echo "Using URL: $URL"
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
 
-      # --- Ping your app ---
-      - name: Smoke test /api/ping
+      - name: Test static health endpoint
         run: |
-          URL="${{ steps.baseurl.outputs.url }}"
-          if [ -z "$URL" ]; then
-            echo "No URL available for smoke test. Marking job successful but skipping."
-            exit 0
-          fi
-          echo "Pinging: $URL/api/ping"
-          curl -sSf "$URL/api/ping" | tee /dev/stdout
+          curl -fsS "https://mags-assistant.vercel.app/health.json" -o /tmp/health.json
+          jq -e '.ok == true' /tmp/health.json
+
+      - name: Smoke test API ping
+        if: env.HAS_API == 'true'
+        run: |
+          curl -sSf "$API_BASE/api/ping" | tee /dev/stdout
+
       - name: Notify failure
         if: failure() && env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != ''
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: node scripts/notify.ts "❌ smoke failed: $GITHUB_RUN_ID"
+
+      - name: Telegram success
+        if: success() && env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != ''
+        run: |
+          curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            -d text="✅ Smoke passed at $(date --iso-8601=seconds)"

--- a/package.json
+++ b/package.json
@@ -2,15 +2,11 @@
   "name": "mags-assistant",
   "private": true,
   "version": "1.0.0",
-
   "scripts": {
-    "build": "echo \"no build step; skipping\""
+    "prebuild": "node scripts/stamp-health.mjs",
+    "build": "echo 'static site build' "
   },
-
-  "engines": {
-    "node": "20.x"
-  },
-
+  "engines": { "node": ">=20 <23" },
   "dependencies": {},
   "devDependencies": {}
 }

--- a/public/check/index.html
+++ b/public/check/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>System Check</title>
+  <link rel="stylesheet" href="/brand.css" />
+  <style>
+    a.pill{display:inline-block;padding:4px 8px;margin:4px;border-radius:9999px;background:#eee;text-decoration:none;color:#000}
+    div.status{margin-top:4px}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>System Check</h1>
+    <div>
+      <a class="pill" id="vercel-link" href="https://mags-assistant.vercel.app/health" target="_blank">Vercel API</a>
+      <div id="vercel-status" class="status"></div>
+    </div>
+    <div>
+      <a class="pill" id="worker-link" href="https://tight-snow-2840.messyandmagnetic.workers.dev" target="_blank">Worker</a>
+      <div id="worker-status" class="status"></div>
+    </div>
+  </div>
+  <script>
+    async function check(id, url){
+      const el=document.getElementById(id);
+      try{
+        const res=await fetch(url);
+        const ok=res.ok?'OK':'FAIL';
+        el.textContent=`${ok} ${res.status}`;
+        el.style.color=res.ok?'green':'red';
+      }catch(e){
+        el.textContent='FAIL';
+        el.style.color='red';
+      }
+    }
+    check('vercel-status','https://mags-assistant.vercel.app/health');
+    check('worker-status','https://tight-snow-2840.messyandmagnetic.workers.dev');
+  </script>
+</body>
+</html>

--- a/public/health.json
+++ b/public/health.json
@@ -1,0 +1,5 @@
+{
+  "ok": true,
+  "ts": "__BUILD_TIME__",
+  "note": "static health probe"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <h1>Mags Assistant — Static deploy OK</h1>
+    <p><a href="/check/">System Check</a></p>
   </body>
 </html>

--- a/public/mags-config.json
+++ b/public/mags-config.json
@@ -4,7 +4,6 @@
     "version": 2,
     "cleanUrls": true
   },
-
   "code_layout": {
     "static_site": true,
     "has_api_routes": false,
@@ -15,13 +14,11 @@
       "public/mags-config.json"
     ]
   },
-
   "endpoints": {
     "status_page": "/check",
     "health": "/health",
     "echo": "/api/echo"
   },
-
   "cloudflare": {
     "worker_url": "https://tight-snow-2840.messyandmagnetic.workers.dev",
     "cron": {
@@ -30,11 +27,13 @@
       "nightly": "/cron/nightly"
     }
   },
-
   "ops": {
     "status_reporting": {
       "enabled": true,
-      "channels": ["GitHub PR comments", "Telegram"]
+      "channels": [
+        "GitHub PR comments",
+        "Telegram"
+      ]
     },
     "telegram": {
       "enabled": true,
@@ -43,7 +42,6 @@
       "default_prefix": "[Mags]"
     }
   },
-
   "project": {
     "owner": "messyandmagnetic",
     "repo": "mags-assistant",
@@ -68,7 +66,6 @@
       ]
     }
   },
-
   "github_actions": {
     "workflows": [
       "cron-runner.yml",
@@ -88,13 +85,16 @@
     "policy": {
       "dispatchable": true,
       "default_branch": "main",
-      "required_permissions": ["contents:write", "pull_requests:write", "actions:read"]
+      "required_permissions": [
+        "contents:write",
+        "pull_requests:write",
+        "actions:read"
+      ]
     },
     "skip_rules": {
       "skip_if_api_base_empty": true
     }
   },
-
   "secrets": {
     "present": [
       "API_BASE",
@@ -121,7 +121,6 @@
       "WORKER_URL": "Cloudflare Worker base URL if different from cloudflare.worker_url."
     }
   },
-
   "guard_rails": {
     "vercel_json_rules": [
       "No legacy now-* runtimes",
@@ -132,5 +131,8 @@
       "Workflows that POST to /api/* must be gated because site is static",
       "If API_BASE is empty or not reachable, skip those jobs instead of failing"
     ]
+  },
+  "deployment": {
+    "prod_url": "https://mags-assistant.vercel.app"
   }
 }

--- a/scripts/stamp-health.mjs
+++ b/scripts/stamp-health.mjs
@@ -1,0 +1,6 @@
+import fs from 'node:fs/promises';
+const p = 'public/health.json';
+let s = await fs.readFile(p, 'utf8');
+s = s.replace('__BUILD_TIME__', new Date().toISOString());
+await fs.writeFile(p, s);
+console.log('Stamped', p);


### PR DESCRIPTION
## Summary
- expose prod and worker base URLs in config and system check UI
- add static health endpoint stamped at build time
- make smoke/cron/nightly workflows tolerant of missing API and add Telegram status

## Testing
- `npm run build`
- `curl -i https://mags-assistant.vercel.app/health.json` *(HTTP 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_689d7fa141ec8327b1f89f062a2b12ee