### PR TITLE
Run Tally registration and backfill

### DIFF
--- a/docs/tally-run-latest.json
+++ b/docs/tally-run-latest.json
@@ -1,0 +1,36 @@
+{
+  "timestamp": "2025-08-14T22:22:55.451Z",
+  "worker_url": "https://tight-snow-2840.messyandmagnetic.workers.dev/tally/webhook",
+  "webhooks": {
+    "3qlZQ9": {
+      "status": "failed",
+      "error": "fetch failed"
+    },
+    "nGPKDo": {
+      "status": "failed",
+      "error": "fetch failed"
+    }
+  },
+  "backfill": {
+    "3qlZQ9": {
+      "processed": 0,
+      "skipped": 0,
+      "error": "fetch failed"
+    },
+    "nGPKDo": {
+      "processed": 0,
+      "skipped": 0,
+      "error": "fetch failed"
+    }
+  },
+  "smoke": {
+    "3qlZQ9": {
+      "ok": false,
+      "error": "connect tunnel failed"
+    },
+    "nGPKDo": {
+      "ok": false,
+      "error": "connect tunnel failed"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `tally-run-latest.json` report for webhook registration and backfill attempt

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e60ee85a883278ccd10645970507a