### PR TITLE
feat: expand TikTok autoposting with booster support

### DIFF
--- a/config/tiktok_usernames.json
+++ b/config/tiktok_usernames.json
@@ -1,0 +1,6 @@
+{
+  "main": "@messyandmagnetic",
+  "alt": "@willowhazeltea",
+  "maggie": "@maggieassistant",
+  "mars": "@messy.mars4"
+}


### PR DESCRIPTION
## Summary
- support multi-account TikTok autoposting using session IDs from secrets
- add booster engagement with human-like delays and varied actions
- wire Telegram logging and configurable username map

## Testing
- `python -m py_compile scripts/extract_clips.py`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f6f043e488327b413a079f1c66d64