### PR TITLE
feat: add TikTok automation backend

### DIFF
--- a/lib/social/providers/tiktok.ts
+++ b/lib/social/providers/tiktok.ts
@@ -1,4 +1,5 @@
 import { loadAccounts, humanizeDelay } from '../tiktokScheduler.js';
+import { content, scheduler } from '../../tiktok/index.js';
 
 export async function post({
   caption,
@@ -11,6 +12,11 @@ export async function post({
   linkUrl?: string;
   scheduleTime?: number;
 }) {
+  const videoId = content.addVideo({
+    title: caption,
+    source_path: mediaUrl,
+    final_filename: mediaUrl,
+  });
   const accounts = await loadAccounts();
   for (const acct of accounts) {
     if (process.env.OFFLINE_MODE === 'true') {
@@ -19,6 +25,10 @@ export async function post({
     }
     if (scheduleTime) {
       console.log(`[tiktok:${acct.username}] schedule`, { caption, mediaUrl, scheduleTime });
+      scheduler.schedulePost({
+        videoId,
+        intended_time: new Date(scheduleTime).toISOString(),
+      });
     } else {
       await new Promise((r) => setTimeout(r, humanizeDelay()));
       console.log(`[tiktok:${acct.username}] post`, {

--- a/lib/tiktok/content.ts
+++ b/lib/tiktok/content.ts
@@ -1,0 +1,33 @@
+import { getDb } from './db.js';
+
+export interface VideoMeta {
+  title?: string;
+  type?: string;
+  emotion?: string;
+  timestamp?: string;
+  quality?: string;
+  source_path?: string;
+  final_filename?: string;
+  tiktok_link?: string;
+  capcut_template?: string;
+  persons?: string[];
+}
+
+export function addVideo(meta: VideoMeta) {
+  const db = getDb();
+  const stmt = db.prepare(
+    `INSERT INTO videos (title, type, emotion, timestamp, quality, source_path, final_filename, tiktok_link, capcut_template)
+     VALUES (@title, @type, @emotion, @timestamp, @quality, @source_path, @final_filename, @tiktok_link, @capcut_template)`
+  );
+  const res = stmt.run(meta);
+  const videoId = Number(res.lastInsertRowid);
+  if (meta.persons && meta.persons.length) {
+    const placeholders = meta.persons.map(() => '?').join(',');
+    const faces = db
+      .prepare(`SELECT id FROM faces WHERE name IN (${placeholders})`)
+      .all(...meta.persons);
+    const insert = db.prepare(`INSERT INTO video_faces (video_id, face_id) VALUES (?, ?)`);
+    for (const f of faces) insert.run(videoId, f.id);
+  }
+  return videoId;
+}

--- a/lib/tiktok/db.ts
+++ b/lib/tiktok/db.ts
@@ -1,0 +1,68 @@
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+
+let db: Database.Database;
+
+export function getDb() {
+  if (!db) {
+    const dataDir = path.join(process.cwd(), 'data');
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    const dbPath = path.join(dataDir, 'tiktok.sqlite');
+    db = new Database(dbPath);
+    db.pragma('journal_mode = WAL');
+    createTables();
+  }
+  return db;
+}
+
+function createTables() {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS faces (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT UNIQUE,
+      encoding BLOB NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS videos (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT,
+      type TEXT,
+      emotion TEXT,
+      timestamp TEXT,
+      quality TEXT,
+      source_path TEXT,
+      final_filename TEXT,
+      tiktok_link TEXT,
+      capcut_template TEXT
+    );
+    CREATE TABLE IF NOT EXISTS video_faces (
+      video_id INTEGER,
+      face_id INTEGER,
+      FOREIGN KEY(video_id) REFERENCES videos(id),
+      FOREIGN KEY(face_id) REFERENCES faces(id)
+    );
+    CREATE TABLE IF NOT EXISTS performance (
+      video_id INTEGER PRIMARY KEY,
+      view_count INTEGER DEFAULT 0,
+      likes INTEGER DEFAULT 0,
+      comments INTEGER DEFAULT 0,
+      shares INTEGER DEFAULT 0,
+      is_flop INTEGER DEFAULT 0,
+      is_viral INTEGER DEFAULT 0,
+      reposts INTEGER DEFAULT 0,
+      sound TEXT,
+      caption TEXT,
+      last_updated TEXT DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(video_id) REFERENCES videos(id)
+    );
+    CREATE TABLE IF NOT EXISTS schedule (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      video_id INTEGER,
+      intended_time TEXT,
+      sound TEXT,
+      emotion TEXT,
+      FOREIGN KEY(video_id) REFERENCES videos(id)
+    );
+  `);
+}

--- a/lib/tiktok/faces.ts
+++ b/lib/tiktok/faces.ts
@@ -1,0 +1,37 @@
+import { getDb } from './db.js';
+
+export interface FaceEncoding {
+  name: string;
+  encoding: number[];
+}
+
+function encodeBuffer(arr: number[]) {
+  return Buffer.from(JSON.stringify(arr));
+}
+
+function decodeBuffer(buf: Buffer) {
+  return JSON.parse(buf.toString()) as number[];
+}
+
+export function saveFace({ name, encoding }: FaceEncoding) {
+  const db = getDb();
+  const stmt = db.prepare(`INSERT OR REPLACE INTO faces (name, encoding) VALUES (?, ?)`);
+  const info = stmt.run(name, encodeBuffer(encoding));
+  return Number(info.lastInsertRowid);
+}
+
+export function matchFace(encoding: number[], threshold = 0.6) {
+  const db = getDb();
+  const faces = db.prepare(`SELECT name, encoding FROM faces`).all();
+  let match: string | null = null;
+  let best = threshold;
+  for (const f of faces) {
+    const enc = decodeBuffer(f.encoding);
+    const dist = Math.sqrt(enc.reduce((acc, val, i) => acc + (val - encoding[i]) ** 2, 0));
+    if (dist < best) {
+      best = dist;
+      match = f.name;
+    }
+  }
+  return match;
+}

--- a/lib/tiktok/index.ts
+++ b/lib/tiktok/index.ts
@@ -1,0 +1,5 @@
+export { getDb } from './db.js';
+export * as content from './content.js';
+export * as faces from './faces.js';
+export * as performance from './performance.js';
+export * as scheduler from './scheduler.js';

--- a/lib/tiktok/performance.ts
+++ b/lib/tiktok/performance.ts
@@ -1,0 +1,34 @@
+import { getDb } from './db.js';
+
+export interface PerformanceInput {
+  videoId: number;
+  view_count: number;
+  likes: number;
+  comments: number;
+  shares: number;
+  sound?: string;
+  caption?: string;
+  reposts?: number;
+}
+
+export function updatePerformance(p: PerformanceInput) {
+  const db = getDb();
+  const flop = p.view_count < 1000 ? 1 : 0;
+  const viral = p.view_count > 100000 ? 1 : 0;
+  const stmt = db.prepare(`
+    INSERT INTO performance (video_id, view_count, likes, comments, shares, sound, caption, reposts, is_flop, is_viral)
+    VALUES (@videoId, @view_count, @likes, @comments, @shares, @sound, @caption, @reposts, @flop, @viral)
+    ON CONFLICT(video_id) DO UPDATE SET
+      view_count=excluded.view_count,
+      likes=excluded.likes,
+      comments=excluded.comments,
+      shares=excluded.shares,
+      sound=COALESCE(excluded.sound, sound),
+      caption=COALESCE(excluded.caption, caption),
+      reposts=COALESCE(excluded.reposts, reposts),
+      is_flop=excluded.is_flop,
+      is_viral=excluded.is_viral,
+      last_updated=CURRENT_TIMESTAMP
+  `);
+  stmt.run({ ...p, flop, viral });
+}

--- a/lib/tiktok/scheduler.ts
+++ b/lib/tiktok/scheduler.ts
@@ -1,0 +1,27 @@
+import { getDb } from './db.js';
+
+export interface ScheduleItem {
+  videoId: number;
+  intended_time: string; // ISO string
+  sound?: string;
+  emotion?: string;
+}
+
+export function schedulePost(item: ScheduleItem) {
+  const db = getDb();
+  const stmt = db.prepare(
+    `INSERT INTO schedule (video_id, intended_time, sound, emotion)
+     VALUES (@videoId, @intended_time, @sound, @emotion)`
+  );
+  const res = stmt.run(item);
+  return Number(res.lastInsertRowid);
+}
+
+export function dailySchedule(date: string) {
+  const db = getDb();
+  return db
+    .prepare(
+      `SELECT * FROM schedule WHERE date(intended_time)=date(?) ORDER BY intended_time LIMIT 12`
+    )
+    .all(date);
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "build": "echo 'static site build' "
   },
   "engines": { "node": ">=20 <23" },
-  "dependencies": {},
-  "devDependencies": {}
+  "dependencies": {
+    "better-sqlite3": "^9.4.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.5"
+  }
 }


### PR DESCRIPTION
## Summary
- add SQLite-backed storage, performance tracking, face recognition, and scheduling modules
- integrate TikTok provider with new backend
- add better-sqlite3 dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fbetter-sqlite3)*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f8d5d76ac8327bf09a6616de4276e