### PR TITLE
feat: add conditional formatting to used content log

### DIFF
--- a/apps-script/UsedContentLog/Code.gs
+++ b/apps-script/UsedContentLog/Code.gs
@@ -10,12 +10,15 @@ const PRIVACY_HEADERS = [
   'quality',
   'sensitive_context',
   'warning',
+  'result',
+  'notes',
 ];
 
 function appendPrivacyLog(entries) {
   const ss = SpreadsheetApp.openById(SHEET_ID);
   const sh = ss.getSheetByName(PRIVACY_TAB) || ss.insertSheet(PRIVACY_TAB);
   ensurePrivacyHeaders_(sh);
+  ensureConditionalFormatting_(sh);
   const existing = sh.getRange(2, 1, Math.max(sh.getLastRow() - 1, 0), PRIVACY_HEADERS.length).getValues();
   entries.forEach((entry) => {
     const ts = entry.ts instanceof Date ? entry.ts : new Date(entry.ts);
@@ -31,6 +34,8 @@ function appendPrivacyLog(entries) {
     if (oversaturated) warnings.push('oversaturation');
     if (quality.toLowerCase() === 'low') warnings.push('low_quality');
     if (sensitive) warnings.push('sensitive_context');
+    const result = entry.result || '';
+    const note = result === 'Success' ? '⭐' : '';
     sh.appendRow([
       ts,
       face,
@@ -41,11 +46,13 @@ function appendPrivacyLog(entries) {
       quality,
       sensitive,
       warnings.join(','),
+      result,
+      note,
     ]);
     if (warnings.some((w) => w !== 'oversaturation')) {
       notifyWarning_(face, video, warnings);
     }
-    existing.push([ts, face, video, visibility, postsToday, oversaturated, quality, sensitive, warnings.join(',')]);
+    existing.push([ts, face, video, visibility, postsToday, oversaturated, quality, sensitive, warnings.join(','), result, note]);
   });
 }
 
@@ -63,6 +70,37 @@ function ensurePrivacyHeaders_(sh) {
     sh.getRange(1, 1, 1, PRIVACY_HEADERS.length).setValues([PRIVACY_HEADERS]);
   }
   sh.setFrozenRows(1);
+}
+
+function ensureConditionalFormatting_(sh) {
+  const resultCol = PRIVACY_HEADERS.indexOf('result') + 1;
+  const notesCol = PRIVACY_HEADERS.indexOf('notes') + 1;
+  if (resultCol < 1 || notesCol < 1) return;
+  const lastRow = sh.getMaxRows();
+  const lastCol = PRIVACY_HEADERS.length;
+  const dataRange = sh.getRange(2, 1, lastRow - 1, lastCol);
+  const colLetter = columnToLetter_(resultCol);
+  const flopRule = SpreadsheetApp.newConditionalFormatRule()
+    .setRanges([dataRange])
+    .whenFormulaSatisfied(`=$${colLetter}2="Flop"`)
+    .setBackground('#f4cccc')
+    .build();
+  const successRule = SpreadsheetApp.newConditionalFormatRule()
+    .setRanges([sh.getRange(2, notesCol, lastRow - 1, 1)])
+    .whenFormulaSatisfied(`=$${colLetter}2="Success"`)
+    .setBackground('#fff2cc')
+    .build();
+  sh.setConditionalFormatRules([flopRule, successRule]);
+}
+
+function columnToLetter_(column) {
+  let temp = '';
+  while (column > 0) {
+    const rem = (column - 1) % 26;
+    temp = String.fromCharCode(65 + rem) + temp;
+    column = Math.floor((column - rem - 1) / 26);
+  }
+  return temp;
 }
 
 function notifyWarning_(face, video, warnings) {


### PR DESCRIPTION
## Summary
- color flop results light red
- mark successful entries with a yellow star in Notes column

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f8f1316508327a7eccad7d27d8010