### PR TITLE
feat: add trend sync utilities

### DIFF
--- a/src/automation/magnet-utils.ts
+++ b/src/automation/magnet-utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Suggest magnet icons based on keyword matches.
+ * For now this just echoes unique keywords.
+ */
+export async function suggestMagnetIcons(keywords: string[]): Promise<string[]> {
+  const unique = Array.from(new Set(keywords.map(k => k.toLowerCase())));
+  return unique.slice(0, 5);
+}

--- a/src/automation/soul-utils.ts
+++ b/src/automation/soul-utils.ts
@@ -1,0 +1,19 @@
+export interface SoulBlueprint {
+  name: string;
+  themes: string[];
+  elements: string[];
+  astro: { sunSign: string };
+}
+
+/**
+ * Minimal placeholder reader for a user's soul blueprint.
+ * In real use, this would query a database or API.
+ */
+export async function readSoulBlueprint(userId: string): Promise<SoulBlueprint> {
+  return {
+    name: userId,
+    themes: ['intuition', 'growth'],
+    elements: ['water', 'air'],
+    astro: { sunSign: 'Gemini' },
+  };
+}

--- a/src/automation/trend-sync.ts
+++ b/src/automation/trend-sync.ts
@@ -1,0 +1,56 @@
+import axios from 'axios';
+import { google } from 'googleapis';
+import { readSoulBlueprint } from './soul-utils';
+import { suggestMagnetIcons } from './magnet-utils';
+
+/** Fetch top trending audio links from TikTok web. */
+export async function fetchTrendingAudios(): Promise<string[]> {
+  const res = await axios.get('https://trends.tiktok.com/sounds');
+  const ids = extractSoundIDs(res.data);
+  return ids.slice(0, 10);
+}
+
+/** Parse TikTok sound IDs from HTML. */
+function extractSoundIDs(html: string): string[] {
+  const regex = /music\/(\w+[^?]*)\?/g;
+  const results: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(html)) !== null) {
+    results.push(`https://www.tiktok.com/music/${match[1]}`);
+  }
+  return results;
+}
+
+/** Generate a simple validating comment/reply pair for a TikTok post. */
+export async function generateComments(emotion: string): Promise<{ comment: string; reply: string }> {
+  const tone = emotion || 'validating';
+  const comment = `When you feel like this... \u{1F4AD} (${tone})`;
+  const reply = 'Exactly why we made this one. \u{1F9E0}\u{1F33F}';
+  return { comment, reply };
+}
+
+/** Append performance analytics to a Google Sheet. */
+export async function appendAnalytics(
+  videoId: string,
+  stats: { likes: number; views: number; shares: number; comments: number }
+) {
+  const sheets = google.sheets('v4');
+  await sheets.spreadsheets.values.append({
+    spreadsheetId: process.env.SHEET_ID!,
+    range: 'Analytics!A1',
+    valueInputOption: 'USER_ENTERED',
+    requestBody: {
+      values: [[new Date().toISOString(), videoId, stats.likes, stats.views, stats.shares, stats.comments]],
+    },
+  });
+}
+
+/** Suggest magnet icons based on a user's soul blueprint keywords. */
+export async function matchSoulToMagnets(userId: string) {
+  const blueprint = await readSoulBlueprint(userId);
+  const keywords = blueprint.themes
+    .concat(blueprint.elements)
+    .concat(blueprint.astro.sunSign);
+  return suggestMagnetIcons(keywords);
+}
+


### PR DESCRIPTION
## Summary
- add trend sync helpers for trending audio scraping, comment generation, analytics logging, and soul magnet matching
- include stub soul blueprint and magnet utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01af7fb948327a61df55dffb3a721