### PR TITLE
feat: persistent TikTok queue with fallback and codex tasks

### DIFF
--- a/codex.config.json
+++ b/codex.config.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "deployTikTokBot": "src/automation/codex-tasks.ts#deployTikTokBot",
+    "healMaggie": "src/automation/codex-tasks.ts#healMaggie",
+    "retryPostQueue": "src/automation/maggie-tiktok.ts#retryPostQueue",
+    "notifyViaTelegram": "src/automation/codex-tasks.ts#notifyViaTelegram"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "prebuild": "node scripts/stamp-health.mjs",
     "build": "echo 'static site build' ",
     "watcher": "ts-node src/automation/watch-raw.ts",
-    "raw-tracker": "ts-node src/automation/watch-raw-tracker.ts"
+    "raw-tracker": "ts-node src/automation/watch-raw-tracker.ts",
+    "deploy:tiktokbot": "ts-node src/automation/codex-tasks.ts"
   },
   "engines": {
     "node": ">=20 <23"
@@ -21,5 +22,8 @@
     "dotenv": "^16.4.0",
     "puppeteer": "^22.0.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.0"
+  }
 }

--- a/queue.json
+++ b/queue.json
@@ -1,0 +1,4 @@
+{
+  "items": [],
+  "failures": []
+}

--- a/src/automation/codex-tasks.ts
+++ b/src/automation/codex-tasks.ts
@@ -1,0 +1,47 @@
+import os from 'os';
+import { MaggieTikTokAutomation, runMaggieTikTokLoop, retryPostQueue, TikTokAutomationEnv } from './maggie-tiktok';
+import { sendTelegram } from './maggie-utils';
+import { getEnv } from '../env.local';
+
+export async function deployTikTokBot() {
+  const env: TikTokAutomationEnv = {
+    TELEGRAM_BOT_TOKEN: await getEnv('TELEGRAM_BOT_TOKEN'),
+    TELEGRAM_CHAT_ID: await getEnv('TELEGRAM_CHAT_ID'),
+    SHEET_ID: await getEnv('SHEET_ID'),
+    DRIVE_FOLDER_ID: await getEnv('DRIVE_FOLDER_ID'),
+    DRIVE_FINAL_FOLDER_ID: await getEnv('DRIVE_FINAL_FOLDER_ID'),
+    BROWSERLESS_URL: await getEnv('BROWSERLESS_URL'),
+    MAKE_FALLBACK_WEBHOOK: await getEnv('MAKE_FALLBACK_WEBHOOK'),
+  };
+  const maggie = new MaggieTikTokAutomation(env);
+  await maggie.watchFolder();
+  await maggie.detectAndRecoverFlops();
+  await maggie.scheduleTikToks();
+  await sendTelegram(env, '🚀 TikTok bot deployed');
+}
+
+export async function healMaggie() {
+  const env: TikTokAutomationEnv = {
+    TELEGRAM_BOT_TOKEN: await getEnv('TELEGRAM_BOT_TOKEN'),
+    TELEGRAM_CHAT_ID: await getEnv('TELEGRAM_CHAT_ID'),
+  };
+  await sendTelegram(env, '🧘 Maggie is on retreat');
+  const check = async () => {
+    const load = os.loadavg()[0];
+    if (load < 0.75) {
+      await sendTelegram(env, '🔄 Maggie returning from retreat');
+      await retryPostQueue();
+    } else {
+      setTimeout(check, 5 * 60 * 1000);
+    }
+  };
+  check();
+}
+
+export async function notifyViaTelegram(text: string) {
+  const env = {
+    TELEGRAM_BOT_TOKEN: await getEnv('TELEGRAM_BOT_TOKEN'),
+    TELEGRAM_CHAT_ID: await getEnv('TELEGRAM_CHAT_ID'),
+  };
+  await sendTelegram(env, text);
+}

--- a/src/env.local.ts
+++ b/src/env.local.ts
@@ -1,1 +1,38 @@
-export const localEnv: Record<string, string | undefined> = {};
+import fetch from 'node-fetch';
+
+export const localEnv: Record<string, string | undefined> = {
+  TELEGRAM_BOT_TOKEN: undefined,
+  TELEGRAM_CHAT_ID: undefined,
+  SHEET_ID: undefined,
+  DRIVE_FOLDER_ID: undefined,
+  DRIVE_FINAL_FOLDER_ID: undefined,
+  BROWSERLESS_URL: undefined,
+  MAKE_FALLBACK_WEBHOOK: undefined,
+};
+
+const cloudKV = {
+  async get(key: string): Promise<string | undefined> {
+    try {
+      const account = process.env.CLOUDFLARE_ACCOUNT_ID;
+      const namespace = process.env.CLOUDFLARE_NAMESPACE_ID;
+      const token = process.env.CLOUDFLARE_API_TOKEN;
+      if (!account || !namespace || !token) return undefined;
+      const url = `https://api.cloudflare.com/client/v4/accounts/${account}/storage/kv/namespaces/${namespace}/values/${key}`;
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) return undefined;
+      return await res.text();
+    } catch {
+      return undefined;
+    }
+  },
+};
+
+export async function getEnv(key: string): Promise<string | undefined> {
+  return (
+    process.env[key] ||
+    localEnv[key] ||
+    (await cloudKV.get(key))
+  );
+}


### PR DESCRIPTION
## Summary
- add Cloudflare KV-backed env fallback via `getEnv`
- persist TikTok post queue with retry, flop detection and caption logic
- wire Codex tasks for deployment and healing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01d3f42b883279dd6a1ac5a15da27