### PR TITLE
feat: enhance TikTok automation

### DIFF
--- a/src/automation/fallback-monitor.ts
+++ b/src/automation/fallback-monitor.ts
@@ -9,10 +9,9 @@ export interface FallbackEnv {
 
 /**
  * monitorBrowserless checks API usage and switches to local Puppeteer if the
- * Browserless limit is reached. A Telegram notification is sent when the switch
- * occurs.
+ * Browserless limit is reached. Returns the usage ratio.
  */
-export async function monitorBrowserless(env: FallbackEnv) {
+export async function monitorBrowserless(env: FallbackEnv): Promise<number> {
   try {
     const url = `https://chrome.browserless.io/metrics?token=${env.BROWSERLESS_TOKEN}`;
     const { data } = await axios.get(url);
@@ -21,8 +20,10 @@ export async function monitorBrowserless(env: FallbackEnv) {
       // TODO: switch to local Puppeteer
       await notify(env, 'Renderer switched — all posts still scheduled.');
     }
+    return usage;
   } catch (err) {
     console.error('🔻Browserless fallback triggered', err);
+    return 1;
   }
 }
 

--- a/src/env.local.ts
+++ b/src/env.local.ts
@@ -1,1 +1,27 @@
+import fetch from 'node-fetch';
+
 export const localEnv: Record<string, string | undefined> = {};
+
+/**
+ * getEnv prefers runtime vars, then process.env, then localEnv.
+ * If not found, it optionally fetches from a remote KV store.
+ */
+export async function getEnv(key: string, env: Record<string, string | undefined> = {}): Promise<string | undefined> {
+  if (env[key]) return env[key];
+  if (process.env[key]) return process.env[key];
+  if (localEnv[key]) return localEnv[key];
+
+  const kv = process.env.CLOUDFLARE_KV_URL || process.env.CODEX_KV_URL;
+  if (kv) {
+    try {
+      const res = await fetch(`${kv}/${key}`);
+      if (res.ok) {
+        const data = await res.json().catch(() => undefined);
+        return data?.value || (await res.text());
+      }
+    } catch (err) {
+      console.error('KV fetch failed', err);
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- add env helper with Cloudflare KV fallback
- persist and retry TikTok queue with healing support
- expose browserless usage for auto healing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a01f4d6b6483278cd8482af698acca