### PR TITLE
feat: durable queue with env fallbacks and emoji captions

### DIFF
--- a/src/automation/maggie-tiktok.ts
+++ b/src/automation/maggie-tiktok.ts
@@ -14,9 +14,12 @@ import {
   SchedulerEnv, startFlopCron, FlopEnv,
   monitorBrowserless, FallbackEnv
 } from './maggie-tasks';
-import { localEnv, getEnv } from '../env.local';
+import { getEnv } from '../lib/getEnv';
+import { getDrive } from '../../lib/google.js';
 
 const delay = (ms: number) => new Promise(res => setTimeout(res, ms));
+
+const QUEUE_FILE = path.join(process.env.QUEUE_DIR || '/tmp', 'queue.json');
 
 function validateEnv(env: TikTokAutomationEnv) {
   const required = [
@@ -46,6 +49,8 @@ export interface TikTokAutomationEnv extends
   TELEGRAM_CHAT_ID?: string;
   BROWSERLESS_URL?: string;
   MAKE_FALLBACK_WEBHOOK?: string;
+  RETRY_DELAY_MS?: number;
+  CAPCUT?: boolean;
 }
 
 interface QueueItem {
@@ -57,34 +62,59 @@ interface QueueItem {
   retries?: number;
   status?: 'queued' | 'processing' | 'failed' | 'posted' | 'flop_final';
   lastError?: string;
+  scheduledTime?: string;
+}
+
+interface QueueState {
+  items: QueueItem[];
+  failures: { id: string; ts: number }[];
+}
+
+export function loadQueue(): QueueState {
+  try {
+    return JSON.parse(fs.readFileSync(QUEUE_FILE, 'utf8')) as QueueState;
+  } catch {
+    return { items: [], failures: [] };
+  }
+}
+
+export function saveQueue(state: QueueState) {
+  try {
+    fs.mkdirSync(path.dirname(QUEUE_FILE), { recursive: true });
+    fs.writeFileSync(QUEUE_FILE, JSON.stringify(state, null, 2));
+  } catch (err) {
+    console.error('Failed to save queue', err);
+  }
+}
+
+const EMOJI_GUIDE: Record<string, string> = {
+  joy: '💛',
+  grief: '🖤',
+  silly: '😂',
+};
+
+async function syncEmojiGuide(sheetId?: string) {
+  if (!sheetId) return;
+  const rows = Object.entries(EMOJI_GUIDE).map(([emotion, emoji]) => [emotion, emoji]);
+  for (const r of rows) {
+    await appendRow({ spreadsheetId: sheetId, range: 'Reference!A:B', values: r });
+  }
 }
 
 class PostQueue {
-  private file = path.resolve('queue.json');
   private items: QueueItem[] = [];
   private failures: { id: string; ts: number }[] = [];
+  private consecutiveFailures = 0;
 
   constructor(private env: TikTokAutomationEnv, private onRetreat: () => Promise<void>) {
-    this.load();
+    const data = loadQueue();
+    this.items = data.items;
+    this.failures = data.failures;
   }
 
-  private load() {
-    if (!fs.existsSync(this.file)) return;
-    try {
-      const data = JSON.parse(fs.readFileSync(this.file, 'utf8'));
-      this.items = data.items || [];
-      this.failures = data.failures || [];
-    } catch (err) {
-      console.error('Failed to load queue', err);
-    }
-  }
-
-  save() {
-    try {
-      fs.writeFileSync(this.file, JSON.stringify({ items: this.items, failures: this.failures }, null, 2));
-    } catch (err) {
-      console.error('Failed to save queue', err);
-    }
+  private save() {
+    saveQueue({ items: this.items, failures: this.failures });
+    this.generatePreview().catch(err => console.error('Preview generation failed', err));
   }
 
   enqueue(item: QueueItem) {
@@ -111,10 +141,14 @@ class PostQueue {
     item.status = 'posted';
     this.update(item);
     console.log(`✅ Posted ${item.id}`);
-    await appendRow({
-      spreadsheetId: this.env.SHEET_ID,
-      values: [item.filename, new Date().toISOString(), 'posted', item.caption || '', item.emotion || '', !!item.useCapCut, false],
-    });
+    this.consecutiveFailures = 0;
+    if (this.env.SHEET_ID) {
+      await appendRow({
+        spreadsheetId: this.env.SHEET_ID,
+        values: [item.filename, new Date().toISOString(), '✅ posted', item.caption || '', item.emotion || '', !!item.useCapCut, false],
+      });
+    }
+    await sendTelegram(this.env, `🎥 New TikTok uploaded: ${item.filename}`);
     this.save();
   }
 
@@ -125,12 +159,24 @@ class PostQueue {
     this.update(item);
     console.log(`❌ Failed ${item.id}: ${reason}`);
     this.failures.push({ id: item.id, ts: Date.now() });
-    await appendRow({
-      spreadsheetId: this.env.SHEET_ID,
-      values: [item.filename, new Date().toISOString(), 'failed', item.caption || '', item.emotion || '', !!item.useCapCut, flopDetected],
-    });
+    this.consecutiveFailures++;
+    if (this.env.SHEET_ID) {
+      await appendRow({
+        spreadsheetId: this.env.SHEET_ID,
+        values: [item.filename, new Date().toISOString(), '❌ failed', item.caption || '', item.emotion || '', !!item.useCapCut, flopDetected],
+      });
+    }
     this.save();
-    if (item.retries >= 3) {
+    const maxRetries = 3;
+    if (item.retries < maxRetries) {
+      const delayMs = this.env.RETRY_DELAY_MS || 5 * 60 * 1000;
+      setTimeout(() => {
+        item.status = 'queued';
+        this.update(item);
+        this.save();
+        sendTelegram(this.env, `🔁 Retry triggered for ${item.filename}`);
+      }, delayMs);
+    } else {
       await sendTelegram(this.env, `Upload failed for ${item.filename}`);
       if (this.env.MAKE_FALLBACK_WEBHOOK) {
         try {
@@ -138,38 +184,43 @@ class PostQueue {
         } catch (err) {
           console.error('Fallback webhook failed', err);
         }
-      } else {
-        await globalThis.codex?.tasks?.retryPostQueue?.();
-        await globalThis.codex?.tasks?.notifyViaTelegram?.(`Upload failed for ${item.filename}`);
       }
     }
-    await this.retreatTrigger();
+    await this.retreatTrigger(item);
   }
 
-  retryFailed() {
-    for (const item of this.items.filter(i => i.status === 'failed' && (i.retries || 0) < 3)) {
-      const delayMs = Math.pow(2, item.retries || 0) * 60 * 1000;
-      setTimeout(() => {
-        item.status = 'queued';
-        this.update(item);
-        this.save();
-      }, delayMs);
+  private async retreatTrigger(item: QueueItem) {
+    if (this.consecutiveFailures >= 3 || (item.retries || 0) >= 3) {
+      this.failures = [];
+      this.save();
+      await this.onRetreat();
     }
   }
 
-  private async retreatTrigger() {
-    const sevenDays = 7 * 24 * 60 * 60 * 1000;
-    const cutoff = Date.now() - sevenDays;
-    const recent = this.failures.filter(f => f.ts >= cutoff);
-    if (recent.length >= 3) {
-      await this.onRetreat();
-      this.failures = [];
-      this.save();
+  private async generatePreview() {
+    const upcoming = this.items.filter(i => i.status === 'queued').slice(0, 5);
+    const rows = upcoming
+      .map(i => `<tr><td>${i.filename}</td><td>${EMOJI_GUIDE[i.emotion || ''] || ''}</td><td>${i.scheduledTime || ''}</td><td>${i.caption || ''}</td></tr>`) // scheduledTime maybe undefined
+      .join('');
+    const html = `<table><tr><th>Filename</th><th>Emoji</th><th>Scheduled</th><th>Caption</th></tr>${rows}</table>`;
+    const filePath = path.join('/tmp', 'queue-preview.html');
+    try {
+      fs.writeFileSync(filePath, html);
+      if (this.env.DRIVE_FINAL_FOLDER_ID) {
+        const drive = await getDrive();
+        await drive.files.create({
+          requestBody: { name: 'schedule-preview.html', parents: [this.env.DRIVE_FINAL_FOLDER_ID], mimeType: 'text/html' },
+          media: { mimeType: 'text/html', body: fs.createReadStream(filePath) },
+        });
+      }
+    } catch (err) {
+      console.error('Failed to generate preview', err);
     }
   }
 }
 
-async function generateCaptionFromEmotion(emotion: string): Promise<string> {
+async function generateCaptionFromEmotion(emotion?: string): Promise<string> {
+  if (!emotion) return 'Let the universe hold this one.';
   if (emotion === 'random') {
     const list = (await fetchTrending()) as string[];
     emotion = list[Math.floor(Math.random() * list.length)] || 'funny';
@@ -178,6 +229,9 @@ async function generateCaptionFromEmotion(emotion: string): Promise<string> {
     validating: 'Overstimulated? Same \uD83D\uDC80',
     funny: 'This is your sign to *not* parent gently today \uD83D\uDE05',
     playful: 'POV: the farm is healing you but the kids are feral',
+    joy: '\uD83D\uDC9B\u2728When your soul lights up for no reason',
+    grief: '\uD83D\uDDA4 Not everything has to be okay today, and that\u2019s okay.',
+    silly: '\uD83D\uDE02 Sometimes healing looks like this.',
   };
   return emotionMap[emotion] || 'Let the universe hold this one.';
 }
@@ -192,7 +246,6 @@ export class MaggieTikTokAutomation {
 
   constructor(private env: TikTokAutomationEnv) {
     this.queue = new PostQueue(this.env, () => this.retreatMode());
-    this.queue.retryFailed();
   }
 
   /**
@@ -275,7 +328,7 @@ export class MaggieTikTokAutomation {
       return;
     }
 
-    if (next.useCapCut) {
+    if (next.useCapCut || this.env.CAPCUT) {
       try {
         await page.click('button[data-e2e="capcut"]');
       } catch (err) {
@@ -325,7 +378,11 @@ export class MaggieTikTokAutomation {
 
   private async retreatMode() {
     this.paused = true;
-    await sendTelegram(this.env, '📉 Retreat mode triggered');
+    await sendTelegram(this.env, '🌙 Maggie has entered fallback retreat mode.');
+    await sendTelegram(this.env, '💤 Maggie is taking a break to recharge. She\'ll be back soon.');
+    setTimeout(() => {
+      this.paused = false;
+    }, 12 * 60 * 60 * 1000);
   }
 
   private async checkFlop(item: QueueItem) {
@@ -351,6 +408,7 @@ export class MaggieTikTokAutomation {
    * Placeholder for other modules like trend insights or Telegram summaries.
    */
   async run(payload: Record<string, any>): Promise<{ ok: boolean }> {
+    await syncEmojiGuide(this.env.SHEET_ID);
     this.watchFolder();
     await this.scheduleTikToks();
     await this.detectAndRecoverFlops();
@@ -373,6 +431,8 @@ export async function retryPostQueue() {
     DRIVE_FINAL_FOLDER_ID: await getEnv('DRIVE_FINAL_FOLDER_ID'),
     BROWSERLESS_URL: await getEnv('BROWSERLESS_URL'),
     MAKE_FALLBACK_WEBHOOK: await getEnv('MAKE_FALLBACK_WEBHOOK'),
+    RETRY_DELAY_MS: parseInt((await getEnv('RETRY_DELAY_MS')) || '300000', 10),
+    CAPCUT: ((await getEnv('CAPCUT')) === 'true'),
   };
   const maggie = new MaggieTikTokAutomation(env);
   await maggie.scheduleTikToks();
@@ -387,6 +447,8 @@ export async function runMaggieTikTokLoop(payload: Record<string, any>, env: Tik
     DRIVE_FINAL_FOLDER_ID: env.DRIVE_FINAL_FOLDER_ID || await getEnv('DRIVE_FINAL_FOLDER_ID'),
     BROWSERLESS_URL: env.BROWSERLESS_URL || await getEnv('BROWSERLESS_URL'),
     MAKE_FALLBACK_WEBHOOK: env.MAKE_FALLBACK_WEBHOOK || await getEnv('MAKE_FALLBACK_WEBHOOK'),
+    RETRY_DELAY_MS: env.RETRY_DELAY_MS ?? parseInt((await getEnv('RETRY_DELAY_MS')) || '300000', 10),
+    CAPCUT: env.CAPCUT ?? ((await getEnv('CAPCUT')) === 'true'),
   };
   validateEnv(mergedEnv);
   const maggie = new MaggieTikTokAutomation(mergedEnv);

--- a/src/automation/maggie-utils.ts
+++ b/src/automation/maggie-utils.ts
@@ -13,13 +13,13 @@ export async function extractEmotionKeywords() {
   console.log('extractEmotionKeywords placeholder');
 }
 
-export async function appendRow({ spreadsheetId, values }: { spreadsheetId?: string; values: any[] }) {
+export async function appendRow({ spreadsheetId, values, range = 'Sheet1!A:G' }: { spreadsheetId?: string; values: any[]; range?: string }) {
   if (!spreadsheetId) {
     console.warn('No spreadsheetId provided for appendRow');
     return;
   }
   try {
-    await appendRows(spreadsheetId, 'Sheet1!A:G', [values]);
+    await appendRows(spreadsheetId, range, [values]);
   } catch (err) {
     console.error('Failed to append row', err);
   }

--- a/src/env.local.ts
+++ b/src/env.local.ts
@@ -8,6 +8,8 @@ export const localEnv: Record<string, string | undefined> = {
   DRIVE_FINAL_FOLDER_ID: undefined,
   BROWSERLESS_URL: undefined,
   MAKE_FALLBACK_WEBHOOK: undefined,
+  RETRY_DELAY_MS: undefined,
+  CAPCUT: undefined,
 };
 
 const cloudKV = {

--- a/src/lib/getEnv.ts
+++ b/src/lib/getEnv.ts
@@ -1,0 +1,1 @@
+export { getEnv } from '../env.local';


### PR DESCRIPTION
## Summary
- add cloud+local env fallback helper and expose getEnv for automation scripts
- persist TikTok queue to /tmp with HTML preview upload and sheet sync
- introduce emoji-based captions, retry alerts, and 12‑hour retreat mode

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a020a713c88327b60b5f6c8fad57f7