### PR TITLE
chore: configure Cloudflare worker env

### DIFF
--- a/src/env.local.ts
+++ b/src/env.local.ts
@@ -10,6 +10,8 @@ export const localEnv: Record<string, string | undefined> = {
   MAKE_FALLBACK_WEBHOOK: undefined,
   RETRY_DELAY_MS: undefined,
   CAPCUT: undefined,
+  CLOUDFLARE_WORKER_URL: 'https://tight-snow-2840.messyandmagnetic.workers.dev',
+  CLOUDFLARE_WORKER_NAME: 'tight-snow-2840',
 };
 
 const cloudKV = {


### PR DESCRIPTION
## Summary
- add Cloudflare worker URL and name to local environment config

## Testing
- `curl -I https://tight-snow-2840.messyandmagnetic.workers.dev` (403 Forbidden)
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0300c4b1083279759b626205bdd81