### PR TITLE
Add combined policy page and update references

### DIFF
--- a/site/app/policy/page.tsx
+++ b/site/app/policy/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy & Terms of Use | Messy & Magnetic',
+  description:
+    'Read the privacy policy and terms of use for Messy & Magnetic covering data collection, usage, and disclaimers.',
+};
+
+export default function PolicyPage() {
+  return (
+    <section className="py-12">
+      <h1 className="mb-6 text-center font-heading text-3xl">
+        Messy &amp; Magnetic™ – Privacy Policy + Terms of Use
+      </h1>
+      <div className="mx-auto max-w-3xl space-y-4 text-brand-ink/80">
+        <h2 className="font-heading text-2xl text-brand-ink">Privacy Policy</h2>
+        <p>
+          Messy &amp; Magnetic™ respects your privacy. This policy outlines what data we
+          collect, how we use it, and how you can opt out.
+        </p>
+        <p>
+          We collect basic info via forms (name, email, birthday, etc.) for the
+          purpose of delivering personalized soul readings and rhythm tools. We
+          never sell your data. We use secure tools like Stripe, Tally, Google
+          Sheets, and automated systems (like GPT or Mags) to fulfill orders and
+          improve the experience. By submitting any form on this site, you agree
+          to this use of your data. We store order data securely and limit access
+          to essential team members only.
+        </p>
+        <p>
+          If you request deletion of your data, contact{' '}
+          <a href="mailto:messyandmagnetic@gmail.com" className="underline">
+            messyandmagnetic@gmail.com
+          </a>{' '}
+          and we will remove your info from our system within 7 business days.
+        </p>
+        <h2 className="mt-8 font-heading text-2xl text-brand-ink">Terms of Use</h2>
+        <p>
+          By using any products, readings, or tools from Messy &amp; Magnetic™,
+          you agree that these are intended for personal insight, self-awareness,
+          and spiritual support only. We are not a substitute for licensed
+          therapy, medical advice, or financial counsel. All content is original
+          or based on public esoteric systems (e.g. Astrology, Human Design)
+          interpreted through our own language. You agree not to redistribute
+          these materials commercially.
+        </p>
+        <p>
+          We reserve the right to modify these terms and will notify users of
+          major changes via the site footer or email when relevant.
+        </p>
+        <p>
+          For any questions or feedback, contact{' '}
+          <a href="mailto:messyandmagnetic@gmail.com" className="underline">
+            messyandmagnetic@gmail.com
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+}
+

--- a/site/app/privacy/page.tsx
+++ b/site/app/privacy/page.tsx
@@ -1,12 +1,6 @@
+import { redirect } from 'next/navigation';
+
 export default function PrivacyPage() {
-  return (
-    <section className="py-12">
-      <h1 className="mb-4 text-center font-heading text-3xl">Privacy &amp; Terms</h1>
-      <iframe
-        src="https://messymagnetic-privacy-policy.super.site"
-        className="h-[80vh] w-full"
-        title="Messy & Magnetic Privacy Policy"
-      />
-    </section>
-  );
+  redirect('/policy');
 }
+

--- a/site/components/Footer.tsx
+++ b/site/components/Footer.tsx
@@ -16,14 +16,9 @@ export default function Footer() {
         <Link href="/contact" className="hover:underline">
           Contact
         </Link>
-        <a
-          href="https://messymagnetic-privacy-policy.super.site"
-          className="hover:underline"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <Link href="/policy" className="hover:underline">
           Privacy &amp; Terms
-        </a>
+        </Link>
       </nav>
       <p>
         Email:{' '}


### PR DESCRIPTION
## Summary
- add `/policy` page with combined Privacy Policy and Terms of Use
- link footer to new policy page
- redirect old `/privacy` route to `/policy`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd798d288327af18b7eb3a80292d