### PR TITLE
Add policy page and update site embeds

### DIFF
--- a/site/app/feedback/page.tsx
+++ b/site/app/feedback/page.tsx
@@ -1,0 +1,18 @@
+import TallyEmbed from '../../components/TallyEmbed';
+import Link from 'next/link';
+
+export default function FeedbackPage() {
+  return (
+    <section className="py-12">
+      <h1 className="mb-4 text-center font-heading text-3xl">Feedback</h1>
+      <TallyEmbed src="https://tally.so/r/nGeWRJ" title="Feedback Form" height={650} />
+      <p className="mt-4 text-center text-sm text-brand-ink/80">
+        I agree to the{' '}
+        <Link href="/policy" className="underline">
+          Messy &amp; Magnetic™ Terms of Use and Privacy Policy
+        </Link>
+        .
+      </p>
+    </section>
+  );
+}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -11,7 +11,7 @@ export default function HomePage() {
       <section className="py-12">
         <h2 className="mb-4 text-center font-heading text-3xl">Create My Soul Flow System</h2>
         <TallyEmbed
-          src={process.env.NEXT_PUBLIC_TALLY_SOUL_FLOW || 'https://tally.so/embed/placeholder'}
+          src="https://tally.so/r/w268rj"
           title="Create My Soul Flow System"
           height={650}
         />

--- a/site/app/policy/page.tsx
+++ b/site/app/policy/page.tsx
@@ -1,0 +1,15 @@
+export default function PolicyPage() {
+  return (
+    <section className="prose mx-auto px-4 py-12">
+      <h1 className="mb-6 text-center font-heading text-3xl">Messy &amp; Magnetic™ – Privacy Policy + Terms of Use</h1>
+      <h2>Privacy Policy</h2>
+      <p>Messy &amp; Magnetic™ respects your privacy. This policy outlines what data we collect, how we use it, and how you can opt out.</p>
+      <p>We collect basic info via forms (name, email, birthday, etc.) for the purpose of delivering personalized soul readings and rhythm tools. We never sell your data. We use secure tools like Stripe, Tally, Google Sheets, and automated systems (like GPT or Mags) to fulfill orders and improve the experience. By submitting any form on this site, you agree to this use of your data. We store order data securely and limit access to essential team members only.</p>
+      <p>If you request deletion of your data, contact <a href="mailto:messyandmagnetic@gmail.com">messyandmagnetic@gmail.com</a> and we will remove your info from our system within 7 business days.</p>
+      <h2>Terms of Use</h2>
+      <p>By using any products, readings, or tools from Messy &amp; Magnetic™, you agree that these are intended for personal insight, self-awareness, and spiritual support only. We are not a substitute for licensed therapy, medical advice, or financial counsel. All content is original or based on public esoteric systems (e.g. Astrology, Human Design) interpreted through our own language. You agree not to redistribute these materials commercially.</p>
+      <p>We reserve the right to modify these terms and will notify users of major changes via the site footer or email when relevant.</p>
+      <p>For any questions or feedback, contact <a href="mailto:messyandmagnetic@gmail.com">messyandmagnetic@gmail.com</a></p>
+    </section>
+  );
+}

--- a/site/app/privacy/page.tsx
+++ b/site/app/privacy/page.tsx
@@ -1,12 +1,5 @@
-export default function PrivacyPage() {
-  return (
-    <section className="py-12">
-      <h1 className="mb-4 text-center font-heading text-3xl">Privacy &amp; Terms</h1>
-      <iframe
-        src="https://messymagnetic-privacy-policy.super.site"
-        className="h-[80vh] w-full"
-        title="Messy & Magnetic Privacy Policy"
-      />
-    </section>
-  );
+import { redirect } from 'next/navigation';
+
+export default function PrivacyRedirect() {
+  redirect('/policy');
 }

--- a/site/app/quiz/page.tsx
+++ b/site/app/quiz/page.tsx
@@ -5,7 +5,7 @@ export default function QuizPage() {
     <section className="py-12">
       <h1 className="mb-4 text-center font-heading text-3xl">Soul Flow Quiz</h1>
       <TallyEmbed
-        src={process.env.NEXT_PUBLIC_TALLY_SOUL_FLOW || 'https://tally.so/embed/placeholder'}
+        src="https://tally.so/r/w268rj"
         title="Create My Soul Flow System"
         height={650}
       />

--- a/site/app/shop/page.tsx
+++ b/site/app/shop/page.tsx
@@ -1,6 +1,3 @@
-'use client';
-
-import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -8,32 +5,64 @@ interface Product {
   id: string;
   name: string;
   price: number;
+  checkoutUrl?: string;
   image?: string | null;
-  description?: string | null;
-  checkoutUrl?: string | null;
 }
 
 const placeholder = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Crect width='300' height='300' fill='%23E8C8C3'/%3E%3C/svg%3E";
 
+const products: Product[] = [
+  {
+    id: 'mini-soul-snapshot',
+    name: 'Mini Soul Snapshot',
+    price: 44,
+    checkoutUrl: process.env.NEXT_PUBLIC_STRIPE_MINI_SOUL_SNAPSHOT,
+  },
+  {
+    id: 'lite-soul-reading',
+    name: 'Lite Soul Reading',
+    price: 88,
+    checkoutUrl: process.env.NEXT_PUBLIC_STRIPE_LITE_SOUL_READING,
+  },
+  {
+    id: 'full-soul-blueprint',
+    name: 'Full Soul Blueprint',
+    price: 144,
+    checkoutUrl: process.env.NEXT_PUBLIC_STRIPE_FULL_SOUL_BLUEPRINT,
+  },
+  {
+    id: 'realignment-blueprint',
+    name: 'Realignment Blueprint',
+    price: 77,
+    checkoutUrl: process.env.NEXT_PUBLIC_STRIPE_REALIGNMENT_BLUEPRINT,
+  },
+  {
+    id: 'addon-reading-44',
+    name: 'Add-on Reading',
+    price: 44,
+    checkoutUrl: process.env.NEXT_PUBLIC_STRIPE_ADDON_44,
+  },
+  {
+    id: 'addon-reading-55',
+    name: 'Add-on Reading',
+    price: 55,
+    checkoutUrl: process.env.NEXT_PUBLIC_STRIPE_ADDON_55,
+  },
+  {
+    id: 'addon-reading-111',
+    name: 'Add-on Reading',
+    price: 111,
+    checkoutUrl: process.env.NEXT_PUBLIC_STRIPE_ADDON_111,
+  },
+  {
+    id: 'gift-magnet-board',
+    name: 'Gift a Magnet Board for a Guest',
+    price: 142,
+    checkoutUrl: process.env.NEXT_PUBLIC_STRIPE_GIFT_MAGNET_BOARD,
+  },
+];
+
 export default function ShopPage() {
-  const [products, setProducts] = useState<Product[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    fetch('/api/products')
-      .then((res) => res.json())
-      .then((data) => setProducts(data.products || []))
-      .finally(() => setLoading(false));
-  }, []);
-
-  if (loading) {
-    return (
-      <section className="py-12 text-center">
-        <p>Loading...</p>
-      </section>
-    );
-  }
-
   return (
     <section className="py-12">
       <h1 className="mb-6 text-center font-heading text-3xl">Shop</h1>
@@ -51,9 +80,6 @@ export default function ShopPage() {
               className="h-48 w-full rounded object-cover"
             />
             <h3 className="mt-4 font-heading">{p.name}</h3>
-            {p.description && (
-              <p className="mt-2 text-sm text-brand-ink/80">{p.description}</p>
-            )}
             <p className="mt-2 text-brand-ink/80">${p.price.toFixed(2)}</p>
             {p.checkoutUrl ? (
               <Link

--- a/site/components/Footer.tsx
+++ b/site/components/Footer.tsx
@@ -16,17 +16,13 @@ export default function Footer() {
         <Link href="/contact" className="hover:underline">
           Contact
         </Link>
-        <a
-          href="https://messymagnetic-privacy-policy.super.site"
-          className="hover:underline"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <Link href="/policy" className="hover:underline">
           Privacy &amp; Terms
-        </a>
+        </Link>
       </nav>
+      <p>EIN 39-3539757 &bull; Retreat: Coyote, NM</p>
       <p>
-        Email:{' '}
+        Email{' '}
         <a href="mailto:hello@messyandmagnetic.com" className="underline">
           hello@messyandmagnetic.com
         </a>


### PR DESCRIPTION
## Summary
- add combined privacy policy and terms page
- embed Tally forms for soul flow and feedback
- replace Stripe product listing with static checkout links
- update footer with EIN, retreat address, and policy link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bda7b1048327abcedb4d37aa646d