### PR TITLE
chore: add tiktok verification metadata

### DIFF
--- a/site/app/policy/page.tsx
+++ b/site/app/policy/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Privacy Policy & Terms of Use | Messy & Magnetic',
+  title: 'Messy & Magnetic™ – Privacy Policy & Terms of Use',
   description:
-    'Read the privacy policy and terms of use for Messy & Magnetic covering data collection, usage, and disclaimers.',
+    'Messy & Magnetic™ Privacy Policy and Terms of Use for all digital products, soul readings, rhythm systems, and retreat programs.',
+  viewport: 'width=device-width, initial-scale=1',
+  robots: { index: true, follow: true },
   alternates: { canonical: '/policy' },
 };
 


### PR DESCRIPTION
## Summary
- add TikTok verification-friendly metadata to policy page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts Fraunces and Inter from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c689d7448327948b524a888bd3a4